### PR TITLE
feat(relay): exponential backoff, multi-relay support, status output fix

### DIFF
--- a/src/aya/status.py
+++ b/src/aya/status.py
@@ -442,9 +442,7 @@ def main(console: Console | None = None) -> None:
     console.print(Rule(style="dim"))
     console.print(f"[dim italic]{_perspective()}[/dim italic]")
     if not all_ok:
-        console.print(
-            f"[yellow]⚠ {total - ok} check(s) degraded — verify paths above.[/yellow]"
-        )
+        console.print(f"[yellow]⚠ {total - ok} check(s) degraded — verify paths above.[/yellow]")
     console.print()
 
 

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -232,12 +232,14 @@ class TestMain:
 
         profile_file = tmp_path / "profile.json"
         profile_file.write_text(
-            json.dumps({
-                "ship_mind_name": "GSV Test",
-                "user_name": "Test",
-                # yesterday — will trigger the "due" branch
-                "name_next_reevaluation_at": "2026-03-22T00:00:00Z",
-            })
+            json.dumps(
+                {
+                    "ship_mind_name": "GSV Test",
+                    "user_name": "Test",
+                    # yesterday — will trigger the "due" branch
+                    "name_next_reevaluation_at": "2026-03-22T00:00:00Z",
+                }
+            )
         )
         monkeypatch.setattr("aya.status.PROFILE", profile_file)
         monkeypatch.setattr("aya.status.get_unseen_alerts", list)


### PR DESCRIPTION
## Summary

- **feat(relay):** Exponential backoff with jitter on relay publish/fetch failures; publishes to and fetches from multiple relays in parallel
- **fix(init):** `--relay` override now correctly sets a single-relay list; omitting it uses the built-in two-relay default instead of an empty list
- **fix(status):** `aya status` was silently printing nothing — ship/user variables were computed but discarded, and every output section was a `pass` stub. Now renders greeting, systems check, focus/priority stack, due reminders, upcoming reminders, active watches, and perspective sign-off via rich.

## Test plan

- [ ] `aya status` renders full output (greeting, systems, focus, reminders, watches)
- [ ] `aya send` retries on relay failure with exponential backoff + jitter
- [ ] Publishing reaches multiple relays when default relay list has 2+ entries
- [ ] `aya init` without `--relay` sets both default relays; `--relay <url>` overrides to single relay
- [ ] `pytest` passes (180 tests green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)