### PR TITLE
chore(pypi): rename package to aya-ai-assist, fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,4 +53,4 @@ jobs:
         # No username/password — uses OIDC trusted publishing
         # Configure trusted publisher on PyPI:
         #   Settings → Publishing → Add publisher
-        #   repo: shawnoster/helm, workflow: release.yml
+        #   repo: shawnoster/aya, workflow: release.yml, environment: pypi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "aya"
+name = "aya-ai-assist"
 version = "0.2.0"
 description = "Personal AI assistant toolkit — sync, schedule, bootstrap"
 readme = "README.md"


### PR DESCRIPTION
## Summary

- `pyproject.toml`: `name = "aya-ai-assist"` — `aya` is taken on PyPI. CLI entry point stays `aya` via `[project.scripts]`, so `pipx install aya-ai-assist` → `aya` command.
- `release.yml`: fix stale comment referencing `shawnoster/helm` (pre-rename); update to `shawnoster/aya` with environment name included.

## PyPI setup checklist

Before merging, confirm on PyPI:

- [ ] Pending publisher project name is `aya-ai-assist`
- [ ] Repository: `shawnoster/aya`
- [ ] Workflow: `release.yml`
- [ ] Environment name: `pypi` (not `pipi`)

And in GitHub repo settings:

- [ ] Environment named `pypi` exists (Settings → Environments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)