### PR TITLE
fix(release): gate build+publish on non-dry-run, add explicit uv build step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,8 +47,12 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           no_operation_mode: ${{ inputs.dry_run || false }}
 
+      - name: Build package
+        if: steps.release.outputs.released == 'true' && inputs.dry_run != true
+        run: uv build
+
       - name: Publish to PyPI
-        if: steps.release.outputs.released == 'true'
+        if: steps.release.outputs.released == 'true' && inputs.dry_run != true
         uses: pypa/gh-action-pypi-publish@release/v1
         # No username/password — uses OIDC trusted publishing
         # Configure trusted publisher on PyPI:


### PR DESCRIPTION
## Summary

- PSR v10 in noop mode outputs `released=true` ("would have released") but skips the actual build, leaving `dist/` empty — the publish step was firing and failing
- Add an explicit `uv build` step so publish is never dependent on PSR's internal build
- Gate both build and publish on `inputs.dry_run != true` so dry runs never touch PyPI

## Test plan

- [ ] Merge and trigger release workflow with **dry_run=true** — build and publish steps should be skipped
- [ ] Trigger with **dry_run=false** — should build, tag, and publish to PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)