### PR TITLE
refactor: canonical profile path is assistant/profile.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ aya bootstrap --root ~/guild
 │   ├── AGENTS.md                 # Duplicate for harness auto-discovery
 │   ├── CLAUDE.md                 # Behavioral instructions
 │   ├── persona.md                # Ship's Mind voice and tone
+│   ├── profile.json              # Persona alias, movement reminders (canonical)
 │   ├── config.json               # Workspace paths (projects_dir, code_dirs)
 │   ├── memory/
 │   │   ├── scheduler.json        # Persistent reminders, watches, crons
@@ -155,9 +156,11 @@ Bootstrap also sets up user-level config:
 
 | File | Purpose |
 | ---- | ---- |
-| `~/.copilot/assistant_profile.json` | Persona, alias, movement reminder cadence |
+| `~/.copilot/assistant_profile.json` | Symlink → `assistant/profile.json` (backward compat) |
 | `~/.claude/settings.json` | SessionStart hooks (health crons, packet receive, scheduler pending) |
 | `~/.claude/hooks/health_crons.sh` | Registers micro-nudge and stand-and-walk cron jobs |
+
+The profile lives in the workspace (`assistant/profile.json`) — not in a harness-specific dotfile. The `~/.copilot/` symlink exists for tools that still look there.
 
 Existing dotfiles are merged, not overwritten. Hooks are deduplicated on re-run.
 
@@ -178,9 +181,11 @@ aya reset --root ~/guild
 ### Preserved on reset
 
 - `assistant/persona.md` — your customized persona
+- `assistant/profile.json` — your alias, movement reminders, identity
 - `assistant/memory/scheduler.json` — your reminders and watches
-- `assistant/notes/` — all daily logs, meeting notes, ideas
-- `projects/` — all project status, plans, discovery docs
+- `assistant/memory/alerts.json` — unseen watcher alerts
+- `assistant/memory/done-log.md` — completed work log
+- `projects/` — all project status, plans, meeting notes, discovery docs
 - Dotfiles (`~/.copilot/`, `~/.claude/`) — not touched by reset
 
 ### Bootstrap-reset cycle

--- a/src/aya/cli.py
+++ b/src/aya/cli.py
@@ -76,7 +76,17 @@ app.add_typer(ci_app, name="ci")
 console = Console()
 err = Console(stderr=True)
 
-DEFAULT_PROFILE = Path.home() / ".copilot" / "assistant_profile.json"
+
+def _find_workspace_root() -> Path:
+    """Walk up from cwd looking for assistant/memory/scheduler.json."""
+    cwd = Path.cwd()
+    for parent in [cwd, *cwd.parents]:
+        if (parent / "assistant" / "memory" / "scheduler.json").exists():
+            return parent
+    return cwd
+
+
+DEFAULT_PROFILE = _find_workspace_root() / "assistant" / "profile.json"
 
 
 def _load_profile(profile_path: Path) -> Profile:

--- a/src/aya/profile.py
+++ b/src/aya/profile.py
@@ -1,4 +1,8 @@
-"""Initialize or rotate the persistent assistant profile in ~/.copilot/assistant_profile.json."""
+"""Initialize or rotate the persistent assistant profile.
+
+Canonical location: {workspace}/assistant/profile.json
+Legacy location:    ~/.copilot/assistant_profile.json (symlinked by bootstrap)
+"""
 
 from __future__ import annotations
 
@@ -19,8 +23,9 @@ def _find_workspace_root() -> Path:
 
 ROOT = _find_workspace_root()
 ACTIVITY_TRACKER_PATH = ROOT / "assistant" / "memory" / "activity-tracker.md"
-PROFILE_PATH = Path.home() / ".copilot" / "assistant_profile.json"
-LEGACY_PROFILE_PATH = Path.home() / ".copilot" / "ace_profile.json"
+PROFILE_PATH = ROOT / "assistant" / "profile.json"
+LEGACY_COPILOT_PATH = Path.home() / ".copilot" / "assistant_profile.json"
+LEGACY_ACE_PATH = Path.home() / ".copilot" / "ace_profile.json"
 REEVALUATION_DAYS = 3
 
 NAME_CANDIDATES = [
@@ -153,9 +158,14 @@ def ensure_profile(path: Path = PROFILE_PATH, now: datetime | None = None) -> di
     now_dt = now or datetime.now(UTC)
     profile = _default_profile(now_dt)
 
-    # Migrate from legacy ace_profile.json if new path doesn't exist yet
-    if not path.exists() and LEGACY_PROFILE_PATH.exists():
-        LEGACY_PROFILE_PATH.rename(path)
+    # Migrate from legacy locations if canonical path doesn't exist yet.
+    # Priority: ~/.copilot/assistant_profile.json > ~/.copilot/ace_profile.json
+    if not path.exists():
+        for legacy in (LEGACY_COPILOT_PATH, LEGACY_ACE_PATH):
+            if legacy.exists() and not legacy.is_symlink():
+                path.parent.mkdir(parents=True, exist_ok=True)
+                legacy.rename(path)
+                break
 
     if path.exists():
         try:

--- a/src/aya/status.py
+++ b/src/aya/status.py
@@ -24,7 +24,7 @@ from aya.scheduler import (
 ROOT = _find_workspace_root()
 ASSISTANT = ROOT / "assistant"
 MEMORY = ASSISTANT / "memory"
-PROFILE = Path.home() / ".copilot" / "assistant_profile.json"
+PROFILE = ASSISTANT / "profile.json"
 CONFIG = ASSISTANT / "config.json"
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -42,7 +42,7 @@ wheels = [
 ]
 
 [[package]]
-name = "aya"
+name = "aya-ai-assist"
 version = "0.2.0"
 source = { editable = "." }
 dependencies = [


### PR DESCRIPTION
## Summary

- Move profile resolution from `~/.copilot/assistant_profile.json` to `{workspace}/assistant/profile.json` across cli, profile, and status modules
- Add `_find_workspace_root()` to cli.py for workspace-relative profile lookup
- Update profile.py migration to handle both legacy paths (`assistant_profile.json`, `ace_profile.json`), preferring the newer one
- Update README: document `profile.json` in bootstrap tree, fix preserved-on-reset list (notes/ → memory files)
- Package renamed to `aya-ai-assist` in uv.lock

## Context

Companion to PR #39. Bootstrap now writes `profile.json` to the workspace and symlinks `~/.copilot/` for backward compat. This PR updates the runtime code to read from the canonical location.

## Test plan

- [x] 303 tests passing
- [x] `ruff check` and `ruff format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)