### PR TITLE
feat(schedule): add recurring CLI command

### DIFF
--- a/src/aya/cli.py
+++ b/src/aya/cli.py
@@ -31,6 +31,7 @@ from aya.relay import RelayClient
 # subcommand is actually called, so startup cost is acceptable.
 from aya.scheduler import (
     _display_items,
+    add_recurring,
     add_reminder,
     add_watch,
     check_due,
@@ -623,6 +624,19 @@ def schedule_watch(
     console.print(f"[green]✓[/green] Watch {item['id'][:8]} ({provider})")
     console.print(f"  {message}")
     console.print(f"  Condition: {item['condition']}, poll every {item['poll_interval_minutes']}m")
+
+
+@schedule_app.command("recurring")
+def schedule_recurring(
+    message: str = typer.Option(..., "--message", "-m", help="Short label for this recurring job"),
+    cron: str = typer.Option(..., "--cron", "-c", help="Cron expression, e.g. '13,43 * * * *'"),
+    prompt: str = typer.Option("", "--prompt", "-p", help="Prompt delivered to Claude each firing"),
+    tag: str = typer.Option("", "--tag", "-t", help="Comma-separated tags"),
+) -> None:
+    """Add a persistent recurring session job (session_required cron)."""
+    item = add_recurring(message, cron, prompt, tag)
+    console.print(f"[green]✓[/green] Recurring {item['id'][:8]} — {cron}")
+    console.print(f"  {message}")
 
 
 @schedule_app.command("list")


### PR DESCRIPTION
## Summary

- Exposes `add_recurring()` as `aya schedule recurring` so persistent session-required cron jobs can be defined in aya rather than injected as raw `CronCreate` instructions from a shell hook.
- Health reminders (micro-nudge + stand-and-move) are now registered via `aya schedule recurring` and surface through `aya schedule pending` on session start.
- `health_crons.sh` is gutted to a no-op — aya owns the definition, Claude Code executes what aya tells it.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor / tech debt
- [ ] Docs / config only

## Related issues

none

## Test plan

- `aya schedule recurring --help` shows the new subcommand
- `aya schedule recurring -m "test" -c "* * * * *" -p "ping"` creates a recurring item
- `aya schedule list --type recurring` shows it
- `aya schedule pending` surfaces it as a session cron to register
- `make check` passes (303 tests)

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, etc.)
- [ ] Tests added or updated for changed behavior
- [x] `make check` passes locally (lint + type-check + tests)
- [x] Pre-commit hooks installed and passing (`make install-hooks` on first clone)
- [x] Docs updated if behavior changed
- [x] No secrets, credentials, or personal data committed