### PR TITLE
fix(receive): add 60s lookback buffer to prevent missing packets

### DIFF
--- a/src/aya/cli.py
+++ b/src/aya/cli.py
@@ -420,12 +420,14 @@ def receive(
         # Update last_checked now that we've successfully fetched from all relays.
         # This is intentionally done before ingestion so the window advances even
         # if the user declines a packet — the 60s buffer above covers re-delivery.
+        # Persisted immediately so the fetch window advances even if ingestion
+        # fails or is interrupted partway through.
         now_iso = datetime.now(UTC).isoformat()
         for url in relay_urls:
             p.last_checked[url] = now_iso
+        p.save(profile)
 
         if not packets:
-            p.save(profile)
             if not quiet:
                 console.print("[dim]No pending packets.[/dim]")
             return
@@ -446,7 +448,6 @@ def receive(
                     )
 
         if not verified:
-            p.save(profile)
             if not quiet:
                 console.print("[dim]No valid packets.[/dim]")
             return


### PR DESCRIPTION
## Summary

- `last_checked` was used as a hard `since=` relay cutoff, silently dropping packets published just before or during a previous receive window — even though `ingested_ids` exists specifically for dedup.
- Adds a 60s lookback buffer so relay propagation delay and clock skew can't cause missed packets. `ingested_ids` remains the authoritative dedup mechanism; `last_checked` is a fetch-window hint only.
- Moves the `last_checked` save to after the fetch (but before ingestion) so the window advances even when the user declines a packet.
- Fixes early-exit paths (empty inbox, no valid packets) to also save the profile.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / tech debt
- [ ] Docs / config only

## Related issues

Discovered during initial work ↔ home relay setup: `aya inbox` showed a packet but `aya receive` did not.

## Test plan

- `aya receive` now picks up packets that arrived between two receive windows
- `aya receive` still skips already-ingested packets via `ingested_ids`
- `make check` passes (303 tests)

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests added or updated for changed behavior
- [x] `make check` passes locally (lint + type-check + tests)
- [x] Pre-commit hooks installed and passing
- [x] No secrets, credentials, or personal data committed