### PR TITLE
fix(receive): drop since filter, rely solely on ingested_ids for dedup

### DIFF
--- a/src/aya/cli.py
+++ b/src/aya/cli.py
@@ -393,15 +393,16 @@ def receive(
         relay_urls = [relay] if relay else p.default_relays
         client = RelayClient(relay_urls, local.nostr_private_hex, local.nostr_public_hex)
 
-        # Fetch all packets addressed to this instance — ingested_ids is the
-        # authoritative dedup mechanism and filters already-seen packets below.
+        # Fetch pending packets for this instance (subject to fetch_pending()'s
+        # limit); ingested_ids is the authoritative dedup mechanism and filters
+        # already-seen packets below.
         packets: list[Packet] = []
         try:
             async for packet in client.fetch_pending():
                 packets.append(packet)
         except Exception:
             if not quiet:
-                err.print("[yellow]Could not reach relay — skipping inbox check.[/yellow]")
+                err.print("[yellow]Could not reach relay — skipping relay fetch.[/yellow]")
             return
 
         if not packets:

--- a/src/aya/relay.py
+++ b/src/aya/relay.py
@@ -169,8 +169,8 @@ class RelayClient:
         Yield packets addressed to this instance's pubkey, querying all relays.
 
         Results are deduplicated by packet ID across relays.  Callers that want
-        a time-bounded fetch can pass *since*; omitting it fetches the full
-        relay history (bounded by *limit*).
+        a time-bounded fetch can pass *since*; omitting it fetches the most
+        recent matching events up to *limit* from each relay.
         """
         seen_ids: set[str] = set()
         for relay_url in self._relay_urls:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,6 +11,7 @@ from typer.testing import CliRunner
 
 from aya.cli import app
 from aya.identity import Identity, Profile, TrustedKey
+from aya.packet import Packet
 from aya.scheduler import add_reminder
 
 runner = CliRunner()
@@ -592,3 +593,112 @@ class TestScheduleStatusCLI:
     def test_tick_exits_zero(self):
         result = runner.invoke(app, ["schedule", "tick", "--quiet"])
         assert result.exit_code == 0
+
+
+# ── receive ───────────────────────────────────────────────────────────────────
+
+
+class TestReceive:
+    @pytest.fixture
+    def sender(self) -> Identity:
+        return Identity.generate("work")
+
+    @pytest.fixture
+    def profile_with_sender(self, profile_with_instance: Path, sender: Identity) -> Path:
+        """Profile with a 'default' instance and 'work' registered as a trusted sender."""
+        p = Profile.load(profile_with_instance)
+        p.trusted_keys["work"] = TrustedKey(
+            did=sender.did, label="work", nostr_pubkey=sender.nostr_public_hex
+        )
+        p.save(profile_with_instance)
+        return profile_with_instance
+
+    def _signed_packet(self, sender: Identity, to_did: str, intent: str = "Test packet") -> Packet:
+        pkt = Packet(
+            **{"from": sender.did, "to": to_did},
+            intent=intent,
+            content="Test content.",
+        )
+        return pkt.sign(sender)
+
+    def test_fetch_pending_called_without_since(
+        self, profile_with_sender: Path, sender: Identity
+    ) -> None:
+        """receive must call fetch_pending() with no since argument."""
+        p = Profile.load(profile_with_sender)
+        packet = self._signed_packet(sender, p.instances["default"].did)
+
+        fetch_calls: list[tuple] = []
+
+        async def mock_fetch(*args, **kwargs):
+            fetch_calls.append((args, kwargs))
+            yield packet
+
+        with patch("aya.cli.RelayClient") as mock_cls:
+            mock_cls.return_value.fetch_pending = mock_fetch
+            runner.invoke(
+                app,
+                ["receive", "--auto-ingest", "--quiet", "--profile", str(profile_with_sender)],
+            )
+
+        assert len(fetch_calls) == 1
+        assert fetch_calls[0] == ((), {})  # called with no positional or keyword args
+
+    def test_skips_already_ingested_packets(
+        self, profile_with_sender: Path, sender: Identity
+    ) -> None:
+        """Packets whose IDs are already in ingested_ids must be silently skipped."""
+        p = Profile.load(profile_with_sender)
+        packet = self._signed_packet(sender, p.instances["default"].did, intent="Already seen")
+        p.ingested_ids.append(packet.id)
+        p.save(profile_with_sender)
+
+        async def mock_fetch(*args, **kwargs):
+            yield packet
+
+        with patch("aya.cli.RelayClient") as mock_cls:
+            mock_cls.return_value.fetch_pending = mock_fetch
+            result = runner.invoke(
+                app,
+                ["receive", "--auto-ingest", "--profile", str(profile_with_sender)],
+            )
+
+        assert "Already seen" not in result.output
+
+    def test_auto_ingest_persists_packet_id(
+        self, profile_with_sender: Path, sender: Identity
+    ) -> None:
+        """After auto-ingesting a trusted packet, its ID must be saved to ingested_ids."""
+        p = Profile.load(profile_with_sender)
+        packet = self._signed_packet(sender, p.instances["default"].did, intent="New packet")
+
+        async def mock_fetch(*args, **kwargs):
+            yield packet
+
+        with patch("aya.cli.RelayClient") as mock_cls:
+            mock_cls.return_value.fetch_pending = mock_fetch
+            result = runner.invoke(
+                app,
+                ["receive", "--auto-ingest", "--profile", str(profile_with_sender)],
+            )
+
+        assert result.exit_code == 0, result.output
+        saved = Profile.load(profile_with_sender)
+        assert packet.id in saved.ingested_ids
+
+    def test_relay_error_shows_friendly_message(self, profile_with_sender: Path) -> None:
+        """A relay connection failure must print a friendly message, not raise."""
+
+        async def mock_fetch(*args, **kwargs):
+            if False:  # pragma: no cover
+                yield  # makes this an async generator
+            raise OSError("connection refused")
+
+        with patch("aya.cli.RelayClient") as mock_cls:
+            mock_cls.return_value.fetch_pending = mock_fetch
+            result = runner.invoke(
+                app,
+                ["receive", "--profile", str(profile_with_sender)],
+            )
+
+        assert "Could not reach relay" in result.output


### PR DESCRIPTION
## Problem

`aya receive` was silently missing packets that `aya inbox` could see. The root cause: `receive` built a `since` timestamp from `last_checked` and filtered the relay query to only return events newer than that window. `last_checked` advanced on every successful relay connection — even empty ones — so any packet published before the latest poll window was permanently invisible to `receive`.

The code itself noted the issue (`last_checked is only a performance optimisation — ingested_ids is the authoritative dedup mechanism`) but the optimisation introduced a correctness bug.

Reproducer: relay returns 503, `last_checked` does not advance. A subsequent successful but empty poll advances it past packets that were sent during the outage. Those packets are now outside the fetch window and never received.

## Solution

Drop the `since` filter from `receive` entirely. `receive` now does a full relay fetch on every call — identical to `inbox` — and relies on `ingested_ids` to skip already-processed packets.

## Changes

- `cli.py`: remove `since` computation, `last_checked` read/write, and `timedelta` import from `receive`
- `relay.py`: update `fetch_pending` docstring to reflect that `since` is optional, not the primary mechanism

## Known follow-ups (tracked separately)

- `ingested_ids` is capped at 100 entries (`identity.py:195`). Now load-bearing as sole dedup guard — should be raised or switched to TTL-based pruning.
- Relay `limit` default of 50 means packets beyond the 50 most-recent are invisible. Low risk at current volume but worth making configurable.

## Test plan

- [x] `tests/test_relay.py` — all passing (75/75)
- [x] `tests/test_cli.py` — all passing
- [x] Live relay test: `aya receive` now surfaces packets that were previously invisible due to `last_checked` drift