### PR TITLE
feat: seed default health-break recurring schedule

### DIFF
--- a/src/aya/cli.py
+++ b/src/aya/cli.py
@@ -55,11 +55,17 @@ from aya.scheduler import (
 )
 from aya.status import run_status
 
+
+def _startup() -> None:
+    """Run once per CLI invocation: migrate legacy data."""
+    migrate_if_needed()
+
+
 app = typer.Typer(
     name="aya",
     help="Personal AI assistant toolkit — sync, schedule, identity.",
     no_args_is_help=True,
-    callback=migrate_if_needed,
+    callback=_startup,
 )
 
 # ── Schedule sub-app ─────────────────────────────────────────────────────────

--- a/src/aya/paths.py
+++ b/src/aya/paths.py
@@ -90,4 +90,41 @@ def migrate_if_needed() -> list[str]:
             old_path.rename(new_path)
             migrated.append(f"{old_rel} → {new_path}")
 
+    if migrated:
+        seeded = seed_defaults()
+        migrated.extend(seeded)
+
     return migrated
+
+
+def seed_defaults() -> list[str]:
+    """Seed default recurring schedules if scheduler is empty.
+
+    Called after migration or on fresh install. Returns descriptions
+    of created items.
+    """
+    from aya.scheduler import add_recurring, load_items  # noqa: PLC0415
+
+    items = load_items()
+    # Skip if any recurring items already exist
+    if any(i.get("type") == "recurring" for i in items):
+        return []
+
+    ensure_home()
+    seeded = []
+
+    item = add_recurring(
+        message="health-break",
+        cron="*/20 * * * *",
+        prompt=(
+            "Deliver a health break reminder to Shawn. Suggest standing up, "
+            "stretching (neck rolls, wrist stretches, or eye rest — 20/20/20 "
+            "rule), getting water, and walking for at least 2 minutes. Keep it "
+            "warm, brief, and varied — two sentences max."
+        ),
+        tags="health,wellness",
+        idle_back_off="10m",
+    )
+    seeded.append(f"health-break (every 20m, idle-aware): {item['id'][:8]}")
+
+    return seeded

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -30,6 +30,47 @@ def aya_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     return home
 
 
+@pytest.fixture
+def aya_scheduler(aya_home: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Set up scheduler isolation alongside aya_home."""
+    mem = aya_home / "memory"
+    mem.mkdir(parents=True, exist_ok=True)
+    scheduler_file = mem / "scheduler.json"
+    alerts_file = mem / "alerts.json"
+    scheduler_file.write_text(json.dumps({"items": []}))
+    alerts_file.write_text(json.dumps({"alerts": []}))
+
+    monkeypatch.setattr("aya.scheduler.SCHEDULER_FILE", scheduler_file)
+    monkeypatch.setattr("aya.scheduler.ALERTS_FILE", alerts_file)
+    return aya_home
+
+
+class TestSeedDefaults:
+    def test_seeds_health_break(self, aya_scheduler: Path) -> None:
+        from aya.paths import seed_defaults
+        from aya.scheduler import load_items
+
+        seeded = seed_defaults()
+        assert len(seeded) == 1
+        assert "health-break" in seeded[0]
+
+        items = load_items()
+        recurring = [i for i in items if i.get("type") == "recurring"]
+        assert len(recurring) == 1
+        assert recurring[0]["message"] == "health-break"
+        assert recurring[0]["cron"] == "*/20 * * * *"
+        assert recurring[0]["idle_back_off"] == "10m"
+
+    def test_skips_when_recurring_exists(self, aya_scheduler: Path) -> None:
+        from aya.paths import seed_defaults
+
+        # First call seeds
+        seed_defaults()
+        # Second call should skip
+        seeded = seed_defaults()
+        assert seeded == []
+
+
 class TestEnsureHome:
     def test_creates_memory_dir(self, aya_home: Path) -> None:
         from aya.paths import ensure_home


### PR DESCRIPTION
## Summary
- Seeds a 20-minute recurring health-break reminder during workspace → `~/.aya` migration
- Every 20 min: stand, stretch, hydrate, walk — warm and varied prompts
- Idle-aware: suppresses after 10m inactivity (no pileup when AFK)
- Only seeds if no recurring items exist yet (idempotent)
- `seed_defaults()` also available for programmatic use

## Test plan
- [x] All 326 tests pass (2 new seed tests)
- [x] Health break created with correct cron, idle_back_off, tags
- [x] Second seed call is a no-op when recurring items exist

Closes #60
Depends on #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)