### PR TITLE
feat: add `aya hook crons` subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Add these hooks to `~/.claude/settings.json` under `"hooks": { "SessionStart": [
 
 `aya hook crons` is the bridge between aya's persistent scheduler and Claude Code's in-session cron system. On each session start it:
 
-1. Calls `get_pending()` to fetch active session-required recurring items
+1. Fetches active session-required recurring items (without claiming alerts)
 2. Filters by idle back-off and work-hours constraints
 3. Outputs a `hookSpecificOutput.additionalContext` block with explicit `CronCreate` instructions
 

--- a/src/aya/cli.py
+++ b/src/aya/cli.py
@@ -44,6 +44,7 @@ from aya.scheduler import (
     format_scheduler_status,
     get_pending,
     get_scheduler_status,
+    get_session_crons,
     is_idle,
     list_items,
     parse_due,
@@ -835,7 +836,7 @@ def schedule_alerts(
         console.print(f"\n  Marked {len(unseen)} alert(s) as seen.")
 
 
-# ��─ hook ──────────────────────────────────────────────────────────────────────
+# ── hook ──────────────────────────────────────────────────────────────────────
 
 
 @hook_app.command("crons")
@@ -846,11 +847,13 @@ def hook_crons() -> None:
     hookSpecificOutput block that tells Claude Code to register them
     via CronCreate.  Exits silently when there are no crons to register.
 
+    Unlike get_pending(), this does NOT claim alerts — safe to run before
+    ``aya schedule pending`` without consuming alerts.
+
     Usage in ~/.claude/settings.json:
         {"command": "aya hook crons", "statusMessage": "Registering crons..."}
     """
-    pending = get_pending()
-    crons = pending.get("session_crons", [])
+    crons, _suppressed = get_session_crons()
     if not crons:
         return
 

--- a/src/aya/scheduler.py
+++ b/src/aya/scheduler.py
@@ -1238,10 +1238,25 @@ def get_pending(instance_id: str | None = None) -> dict[str, Any]:
                     a["delivered_by"] = instance_id
             _atomic_write(_alerts_file(), {"alerts": alerts})
 
-    # Collect session-required recurring items, applying idle / work-hours filters.
+    session_crons, suppressed_crons = get_session_crons()
+
+    return {
+        "alerts": deliverable,
+        "session_crons": session_crons,
+        "suppressed_crons": suppressed_crons,
+        "instance_id": instance_id,
+    }
+
+
+def get_session_crons() -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Return active session crons, filtered by idle back-off and work hours.
+
+    Returns (active_crons, suppressed_crons) without any alert side effects.
+    Use this when you only need crons — get_pending() also claims alerts.
+    """
     now = datetime.now(_get_local_tz())
     items = load_items()
-    active_crons = [
+    active = [
         i
         for i in items
         if i.get("type") == "recurring"
@@ -1250,7 +1265,7 @@ def get_pending(instance_id: str | None = None) -> dict[str, Any]:
     ]
     session_crons = []
     suppressed_crons = []
-    for item in active_crons:
+    for item in active:
         only_during = item.get("only_during", "")
         idle_back_off_str = item.get("idle_back_off", "")
         if only_during and not is_within_work_hours(only_during, now):
@@ -1261,13 +1276,7 @@ def get_pending(instance_id: str | None = None) -> dict[str, Any]:
             suppressed_crons.append({"item": item, "reason": reason})
         else:
             session_crons.append(item)
-
-    return {
-        "alerts": deliverable,
-        "session_crons": session_crons,
-        "suppressed_crons": suppressed_crons,
-        "instance_id": instance_id,
-    }
+    return session_crons, suppressed_crons
 
 
 def format_pending(pending: dict[str, Any]) -> str:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -532,6 +532,82 @@ def _isolate_scheduler(tmp_path, monkeypatch):
 
 
 @pytest.mark.usefixtures("_isolate_scheduler")
+class TestHookCrons:
+    def test_no_crons_exits_silently(self):
+        result = runner.invoke(app, ["hook", "crons"])
+        assert result.exit_code == 0
+        assert result.output.strip() == ""
+
+    def test_outputs_valid_json_with_crons(self, tmp_path, monkeypatch):
+        scheduler_file = tmp_path / "sched" / "scheduler.json"
+        alerts_file = tmp_path / "sched" / "alerts.json"
+        scheduler_file.parent.mkdir(parents=True)
+        scheduler_file.write_text(
+            json.dumps(
+                {
+                    "items": [
+                        {
+                            "id": "test-cron",
+                            "type": "recurring",
+                            "status": "active",
+                            "created_at": "2026-01-01T00:00:00-07:00",
+                            "message": "test",
+                            "session_required": True,
+                            "cron": "*/20 * * * *",
+                            "prompt": "Do the thing.",
+                        }
+                    ]
+                }
+            )
+        )
+        alerts_file.write_text(json.dumps({"alerts": []}))
+        monkeypatch.setattr("aya.scheduler.SCHEDULER_FILE", scheduler_file)
+        monkeypatch.setattr("aya.scheduler.ALERTS_FILE", alerts_file)
+
+        result = runner.invoke(app, ["hook", "crons"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "hookSpecificOutput" in data
+        ctx = data["hookSpecificOutput"]["additionalContext"]
+        assert "CronCreate" in ctx
+        assert "test-cron" in ctx
+
+    def test_does_not_claim_alerts(self, tmp_path, monkeypatch):
+        """hook crons must not consume alerts — they belong to schedule pending."""
+        scheduler_file = tmp_path / "sched" / "scheduler.json"
+        alerts_file = tmp_path / "sched" / "alerts.json"
+        scheduler_file.parent.mkdir(parents=True)
+        scheduler_file.write_text(json.dumps({"items": []}))
+        alerts_file.write_text(
+            json.dumps(
+                {
+                    "alerts": [
+                        {
+                            "id": "alert-1",
+                            "source_item_id": "watch-1",
+                            "created_at": "2026-01-01T00:00:00-07:00",
+                            "message": "PR merged",
+                            "details": {},
+                            "seen": False,
+                        }
+                    ]
+                }
+            )
+        )
+        monkeypatch.setattr("aya.scheduler.SCHEDULER_FILE", scheduler_file)
+        monkeypatch.setattr("aya.scheduler.ALERTS_FILE", alerts_file)
+
+        # Run hook crons
+        runner.invoke(app, ["hook", "crons"])
+
+        # Alerts must still be unseen
+        alerts = json.loads(alerts_file.read_text())["alerts"]
+        assert len(alerts) == 1
+        assert alerts[0]["seen"] is False
+        assert "delivered_at" not in alerts[0]
+
+
+@pytest.mark.usefixtures("_isolate_scheduler")
 class TestScheduleStatusCLI:
     def test_status_exits_zero(self):
         result = runner.invoke(app, ["schedule", "status"])


### PR DESCRIPTION
## Summary
- New `aya hook crons` subcommand that reads session crons from the scheduler and outputs `hookSpecificOutput` JSON with `CronCreate` instructions
- Replaces the external `health_crons.sh` Python-in-bash script — no shell scripts to scaffold on new machines
- Ships with the package, stays in sync on `uv tool upgrade`
- Uses `console.out()` for JSON output (no Rich wrapping, depends on #67)

## Usage

In `~/.claude/settings.json`:
```json
{"command": "aya hook crons", "statusMessage": "Registering crons..."}
```

## Test plan
- [x] 308 tests pass
- [x] `aya hook crons | python3 -m json.tool` produces valid JSON
- [x] Exits silently (no output) when no session crons pending
- [x] Picks up health-break cron registered via `aya schedule recurring`

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)