### PR TITLE
docs: add one-prompt setup guide and relay polling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,8 +54,7 @@ aya receive --instance home --auto-ingest --quiet
 
 # Set up recurring relay poll (persists across sessions)
 aya schedule recurring -m "relay-poll" -c "*/10 * * * *" \
-  -p "Run: aya receive --instance home --auto-ingest --quiet. If any packets were ingested, surface their content to the user." \
-  --idle-back-off 30m
+  -p "Run: aya receive --instance home --auto-ingest --quiet. If any packets were ingested, surface their content to the user."
 ```
 
 > **New machine?** See the "One-prompt setup" section in `README.md` for a single prompt that installs aya, pairs instances, wires hooks, and registers relay polling.

--- a/README.md
+++ b/README.md
@@ -114,9 +114,9 @@ CCR minimum interval is 1 hour. aya can fire at any cron interval.
 
 Already have aya installed on another machine? Give Claude Code this prompt on the new machine and it will handle everything:
 
-> Install aya (`uv tool install aya-ai-assist`), initialize identity with `aya init --label <LABEL>` (use "home" or "work"), then pair with my other instance — run `aya pair --label <LABEL> --instance <LABEL>` and give me the pairing code (or use `--code <CODE>` if I already have one). After pairing, set up Claude Code hooks by adding the aya SessionStart and PostToolUse hooks to `~/.claude/settings.json` (see the "Agent integration" section of the aya README for the exact JSON). Finally, register a relay poll cron: `aya schedule recurring -m "relay-poll" -c "*/10 * * * *" -p "Run: aya receive --instance <LABEL> --auto-ingest --quiet. If any packets were ingested, surface their content to the user." --idle-back-off 30m`. Verify everything works with `aya status`.
+> Install aya (`uv tool install aya-ai-assist`), initialize identity with `aya init --label <LABEL>` (use "home" or "work"), then pair with my other instance. If I have a pairing code from the other machine, run `aya pair --code <CODE> --label <OTHER_LABEL> --instance <LABEL>` and we're done. If not, run `aya pair --label <OTHER_LABEL> --instance <LABEL>` — this will block waiting for the other machine to join (up to 10 minutes), so give me the short code it displays and immediately run `aya pair --code <CODE>` on the other machine before the window expires. After pairing, set up Claude Code hooks by adding the aya SessionStart and PostToolUse hooks to `~/.claude/settings.json` (see [AGENTS.md](./AGENTS.md) for a full example). Finally, register a relay poll cron: `aya schedule recurring -m "relay-poll" -c "*/10 * * * *" -p "Run: aya receive --instance <LABEL> --auto-ingest --quiet. If any packets were ingested, surface their content to the user."`. Verify everything works with `aya status`.
 
-Replace `<LABEL>` with this machine's role (`home` or `work`) and `<CODE>` with a pairing code from the other machine if you have one.
+Replace `<LABEL>` with this machine's role (`home` or `work`), `<OTHER_LABEL>` with the other machine's role, and `<CODE>` with the pairing code.
 
 ### What that prompt does
 


### PR DESCRIPTION
## Summary
- Add "One-prompt setup" section to README — a single prompt users can paste into Claude Code on a new machine to install, init, pair, wire hooks, and register relay polling
- Add relay-poll recurring cron example to AGENTS.md dispatch section
- Cross-reference from AGENTS.md to the new README section

## Test plan
- [ ] Verify the one-prompt setup instructions work on a fresh machine
- [ ] Confirm `aya schedule recurring` relay-poll command works as documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)