### PR TITLE
fix(relay): skip pairing events in fetch_pending

### DIFF
--- a/src/aya/pair.py
+++ b/src/aya/pair.py
@@ -13,6 +13,8 @@ import websockets
 
 from aya.identity import Identity, TrustedKey
 from aya.relay import (
+    _PAIR_TAG_REQ,
+    _PAIR_TAG_RESP,
     AYA_KIND,
     _backoff_delay,
     _compute_event_id,
@@ -288,8 +290,8 @@ WORD_LIST: tuple[str, ...] = (
     "GARNET",
 )
 
-_TAG_PAIR_REQ = "aya-pair-req"
-_TAG_PAIR_RESP = "aya-pair-resp"
+_TAG_PAIR_REQ = _PAIR_TAG_REQ
+_TAG_PAIR_RESP = _PAIR_TAG_RESP
 
 
 def generate_code() -> str:

--- a/src/aya/relay.py
+++ b/src/aya/relay.py
@@ -22,6 +22,13 @@ logger = logging.getLogger(__name__)
 AYA_KIND = 5999
 AYA_RESULT_KIND = 6999  # read receipts / replies
 
+# Pairing event type tags — same kind as packets but not Packet-shaped.
+# Defined here (not in pair.py) so relay.py can filter them without a
+# circular import (pair.py already imports relay.py).
+_PAIR_TAG_REQ = "aya-pair-req"
+_PAIR_TAG_RESP = "aya-pair-resp"
+_PAIR_TAGS: frozenset[str] = frozenset({_PAIR_TAG_REQ, _PAIR_TAG_RESP})
+
 # Retry / backoff configuration
 _BACKOFF_BASE = 1.0  # seconds for first retry
 _BACKOFF_CAP = 60.0  # maximum sleep between retries
@@ -204,21 +211,19 @@ class RelayClient:
                         async for raw in _read_until_eose(ws, sub_id):
                             try:
                                 # Skip pairing events — same kind (5999) but not
-                                # Packet-shaped. Check tags to avoid circular import
-                                # from pair.py (which already imports relay.py).
+                                # Packet-shaped. Constants live in relay.py to avoid
+                                # a circular import with pair.py.
                                 event_tags = raw.get("tags", [])
-                                if any(
-                                    len(t) >= 2
-                                    and t[0] == "t"
-                                    and t[1] in ("aya-pair-req", "aya-pair-resp")
-                                    for t in event_tags
-                                ):
-                                    logger.debug(
-                                        "Skipping pairing event (tag=%s)",
-                                        next(
-                                            t[1] for t in event_tags if len(t) >= 2 and t[0] == "t"
-                                        ),
-                                    )
+                                pairing_tag = next(
+                                    (
+                                        t
+                                        for t in event_tags
+                                        if len(t) >= 2 and t[0] == "t" and t[1] in _PAIR_TAGS
+                                    ),
+                                    None,
+                                )
+                                if pairing_tag is not None:
+                                    logger.debug("Skipping pairing event (tag=%s)", pairing_tag[1])
                                     continue
                                 packet = Packet.from_json(raw["content"])
                                 if not packet.is_expired():

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -401,7 +401,7 @@ class TestFetchPending:
         """Pairing events (tagged aya-pair-req/resp) must not be parsed as Packets."""
         pairing_event = {
             "id": "pair-evt",
-            "tags": [["t", pair_tag], ["p", "somepubkey"]],
+            "tags": [["t", pair_tag], ["p", client.public_key_hex]],
             "content": '{"code": "WORD-WORD-1234"}',
         }
 


### PR DESCRIPTION
## Summary

- Pairing events (kind 5999, tagged `aya-pair-req` / `aya-pair-resp`) share the same Nostr kind as packets but lack the `from`/`to`/`intent` fields — `Packet.from_json()` was raising `KeyError` and logging a warning for every pairing handshake observed on the relay
- Fix: check event tags before attempting packet parse in `_fetch_from_relay`; skip any event tagged `aya-pair-req` or `aya-pair-resp`
- Inline string constants used instead of importing from `pair.py` to avoid a circular import (`pair.py` already imports `relay.py`)

## Changes

- `src/aya/relay.py` — tag filter added in `_fetch_from_relay` inner loop
- `tests/test_relay.py` — two new parametrized tests (`aya-pair-req` and `aya-pair-resp`) asserting pairing events produce no packets

## Test plan

- [ ] `uv run pytest tests/test_relay.py` — all 45 tests pass
- [ ] CI green

Closes [#77](https://github.com/shawnoster/aya/issues/77)