### PR TITLE
feat: add /aya-install skill for global reinstallation

### DIFF
--- a/.claude/commands/aya-refresh.md
+++ b/.claude/commands/aya-refresh.md
@@ -1,14 +1,12 @@
 ---
-name: aya-install
-description: Reinstall aya globally via uv tool after pulling updates from main
-triggers:
-  - "reinstall aya"
-  - "refresh aya"
-  - "update aya globally"
-  - "aya refresh"
+name: aya-refresh
+description: >
+  Refresh aya to the latest version after pulling updates. Uninstalls the current
+  installation and reinstalls from GitHub, with verification. Invoke when the user
+  says "refresh aya", "reinstall aya", "update aya globally", or "aya refresh".
 ---
 
-# Reinstall aya globally
+# Refresh aya
 
 Uninstall the current aya installation and reinstall the latest version from GitHub, with verification.
 


### PR DESCRIPTION
## Summary

Add `/aya-refresh` command to streamline post-update reinstallation.

**What it does:**
- Uninstalls current aya version
- Installs latest from GitHub
- Verifies installation with `aya status`

Placed in `.claude/commands/` alongside other aya-* commands (`/aya-setup`, `/aya-pair`, etc).

## Usage

After pulling aya updates:
```
/aya-refresh
```

## Why

Users frequently need to reinstall after updating. Naming distinction:
- `/aya-setup` = initial configuration (identity, hooks)
- `/aya-refresh` = post-update reinstall

A single slash command is faster and less error-prone than remembering the multi-step process.

🤖 Generated with [Claude Code](https://claude.ai/code)