### PR TITLE
fix: pair command stores peer DID under --peer label

### DIFF
--- a/tests/test_pair.py
+++ b/tests/test_pair.py
@@ -248,7 +248,7 @@ class TestPairingFlowMocked:
             patch("aya.pair._find_pair_request", return_value=request_event),
             patch("aya.pair.websockets.connect", return_value=CapturingWS()),
         ):
-            await join_pairing(home, "work", code, "wss://relay.test")
+            await join_pairing(home, code, "wss://relay.test")
 
         assert sent_events, "Expected a response event to be sent"
         response_content = json.loads(sent_events[0]["content"])


### PR DESCRIPTION
## Summary

- Stores the peer identity under the user-supplied `--peer` label rather than the local label; previously, `p.trusted_keys[trusted.label]` used the label from the response content (the initiator's own label), causing the peer DID to overwrite the local self-trust entry.
- Removes unused `label` parameter from `join_pairing` — the function derives the label from the identity directly.
- Relaxes `requires-python` to `>=3.12` (from `>=3.13`) to match prebuilt coincurve wheel availability.

## Test plan

- [ ] `uv run pytest tests/test_pair.py -q` — all 29 tests pass
- [ ] `uv run ruff check src tests && uv run ruff format --check src tests` — no issues
- [ ] Initiator stores peer DID under `--peer` label, not the local label (regression covered by `test_initiator_stores_peer_under_peer_label`)
- [ ] Joiner stores initiator DID under `--peer` label (covered by `test_joiner_stores_peer_under_peer_label`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)