### PR TITLE
feat: add --dry-run to relay-publishing and state-mutating commands

### DIFF
--- a/src/aya/cli.py
+++ b/src/aya/cli.py
@@ -395,7 +395,7 @@ def send(
     packet = Packet.from_json(packet_file.read_text())
 
     if dry_run:
-        console.print_json(data=json.loads(packet.to_json()))
+        _output_json(json.loads(packet.to_json()))
         raise typer.Exit(0)
 
     client = RelayClient(relay_urls, local.nostr_private_hex, local.nostr_public_hex)
@@ -489,7 +489,7 @@ def dispatch(
         signed = packet.sign(local)
 
         if dry_run:
-            console.print_json(data=json.loads(signed.to_json()))
+            _output_json(json.loads(signed.to_json()))
             return
 
         relay_urls = [relay] if relay else p.default_relays
@@ -641,7 +641,7 @@ def ack(
         signed = ack_packet.sign(local)
 
         if dry_run:
-            console.print_json(data=json.loads(signed.to_json()))
+            _output_json(json.loads(signed.to_json()))
             return
 
         relay_urls = [relay] if relay else p.default_relays
@@ -920,7 +920,7 @@ def pair(
         }
         if code:
             summary["code"] = code
-        console.print_json(data=summary)
+        _output_json(summary)
         raise typer.Exit(0)
 
     if code:
@@ -1010,7 +1010,7 @@ def schedule_remind(
             "tags": [t.strip() for t in tag.split(",") if t.strip()] if tag else [],
             "due_at": due_dt.isoformat(),
         }
-        console.print_json(data=preview)
+        _output_json(preview)
         raise typer.Exit(0)
     item = add_reminder(message, due, tag)
     due_dt = parse_due(due)
@@ -1060,7 +1060,7 @@ def schedule_watch(
             "poll_interval_minutes": interval,
             "remove_when": remove_when,
         }
-        console.print_json(data=preview)
+        _output_json(preview)
         raise typer.Exit(0)
     try:
         item = add_watch(provider, target, message, tag, condition, interval, remove_when)
@@ -1109,7 +1109,7 @@ def schedule_recurring(
             "idle_back_off": idle_back_off,
             "only_during": only_during,
         }
-        console.print_json(data=preview)
+        _output_json(preview)
         raise typer.Exit(0)
     try:
         item = add_recurring(message, cron, prompt, tag, idle_back_off, only_during)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2236,7 +2236,11 @@ class TestDryRun:
         output_data = json.loads(result.output)
         assert output_data["type"] == "watch"
         assert output_data["provider"] == "github-pr"
+        assert output_data["target"] == "owner/repo#42"
         assert output_data["condition"] == "approved_or_merged"
+        assert output_data["message"] == "PR ready"
+        assert output_data["status"] == "active"
+        assert output_data["poll_interval_minutes"] == 30
         data = json.loads(scheduler_file.read_text())
         assert len(data["items"]) == 0
 
@@ -2275,6 +2279,10 @@ class TestDryRun:
         output_data = json.loads(result.output)
         assert output_data["type"] == "recurring"
         assert output_data["cron"] == "*/15 * * * *"
+        assert output_data["prompt"] == "Take a break"
+        assert output_data["message"] == "health check"
+        assert output_data["status"] == "active"
+        assert output_data["session_required"] is True
         data = json.loads(scheduler_file.read_text())
         assert len(data["items"]) == 0
 


### PR DESCRIPTION
## Summary
- Add `--dry-run` / `-n` flag to `send`, `dispatch`, `ack`, `pair`, `schedule remind`, `schedule watch`, and `schedule recurring` commands
- When passed, each command validates inputs and builds the object it would create, outputs it as JSON to stdout, then exits 0 without executing side effects (no relay publish, no file write)
- Add `TestDryRun` class with tests for send, dispatch, ack, and schedule remind dry-run behavior

## Test plan
- [x] `uv run pytest tests/test_cli.py -q` — 90 tests pass
- [x] `uv run ruff check src tests` — clean
- [ ] Manual: `aya send <packet> --dry-run` prints JSON, does not publish
- [ ] Manual: `aya dispatch --to home --intent test --dry-run` prints JSON, does not publish

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)