### PR TITLE
fix: label keypair roles in CLI output

### DIFF
--- a/src/aya/cli.py
+++ b/src/aya/cli.py
@@ -1138,7 +1138,8 @@ def pair(
         lines = [
             "[bold green]✓ Paired![/bold green]\n",
             f"Trusted: [cyan]{peer}[/cyan]",
-            f"DID:     [dim]{trusted.did}[/dim]  [dim italic](ed25519)[/dim italic]",
+            f"DID:     [dim]{trusted.did}[/dim]"
+            "  [dim italic](ed25519 · identity & signing)[/dim italic]",
         ]
         if trusted.nostr_pubkey:
             lines.append(
@@ -1215,7 +1216,8 @@ def pair(
         lines = [
             "[bold green]✓ Paired![/bold green]\n",
             f"Trusted: [cyan]{peer}[/cyan]",
-            f"DID:     [dim]{trusted.did}[/dim]  [dim italic](ed25519)[/dim italic]",
+            f"DID:     [dim]{trusted.did}[/dim]"
+            "  [dim italic](ed25519 · identity & signing)[/dim italic]",
         ]
         if trusted.nostr_pubkey:
             lines.append(


### PR DESCRIPTION
## Summary
- Annotates CLI output with cryptographic role labels so users understand the dual-keypair model: ed25519 for identity/signing, secp256k1 for relay transport.
- Updated `init`, `trust`, and both `pair` paths (joiner + initiator).
- JSON output unchanged — role labeling is a human-readable concern only.

Closes #156

## Test plan
- [x] `uv run pytest tests/test_cli.py -q` — 103 passed
- [x] `uv run ruff check src tests` — all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)