### PR TITLE
refactor: standardize logging across all modules with --verbose flag

### DIFF
--- a/src/aya/ci.py
+++ b/src/aya/ci.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import json
+import logging
 import subprocess
 import sys
 import time
 from collections.abc import Callable
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 _POLL_INTERVAL = 30
 _MAX_WAIT = 600

--- a/src/aya/cli.py
+++ b/src/aya/cli.py
@@ -111,6 +111,18 @@ app = typer.Typer(
     no_args_is_help=True,
 )
 
+
+@app.callback()
+def main(
+    verbose: bool = typer.Option(False, "--verbose", "-v", help="Enable debug logging"),
+) -> None:
+    """aya — personal AI assistant toolkit."""
+    if verbose:
+        logging.basicConfig(level=logging.DEBUG, format="%(name)s %(levelname)s: %(message)s")
+    else:
+        logging.basicConfig(level=logging.WARNING)
+
+
 # ── Schedule sub-app ─────────────────────────────────────────────────────────
 
 schedule_app = typer.Typer(
@@ -581,6 +593,7 @@ def send(
     ),
 ) -> None:
     """Send a packet to a Nostr relay."""
+    logger.debug("send: packet_file=%s, as=%s", packet_file, as_)
     if instance is not None and as_ != "default":
         _emit_error(
             ErrorCode.INVALID_ARGUMENT,
@@ -671,6 +684,7 @@ def dispatch(
     ),
 ) -> None:
     """Pack and send in one step — the natural 'pack for home' flow."""
+    logger.debug("dispatch: to=%s, intent=%s, as=%s", to, intent, as_)
     if instance is not None and as_ != "default":
         _emit_error(
             ErrorCode.INVALID_ARGUMENT,
@@ -1005,6 +1019,7 @@ def receive(
     ),
 ) -> None:
     """Poll for pending packets and surface them for review."""
+    logger.debug("receive: as=%s, auto_ingest=%s, quiet=%s", as_, auto_ingest, quiet)
     if instance is not None and as_ != "default":
         _emit_error(
             ErrorCode.INVALID_ARGUMENT,

--- a/src/aya/config.py
+++ b/src/aya/config.py
@@ -7,10 +7,13 @@ notebook_path that aya needs to find user data.
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 from typing import Any
 
 from aya.paths import CONFIG_PATH
+
+logger = logging.getLogger(__name__)
 
 
 def load_config(path: Path = CONFIG_PATH) -> dict[str, Any]:

--- a/src/aya/context.py
+++ b/src/aya/context.py
@@ -6,10 +6,13 @@ Entry point: build_context_block().
 
 from __future__ import annotations
 
+import logging
 import re
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 # ── Project type classification ───────────────────────────────────────────────
 

--- a/src/aya/encryption.py
+++ b/src/aya/encryption.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import base64
 import hmac as _hmac
+import logging
 import os
 
 from coincurve import PrivateKey as Secp256k1PrivateKey
@@ -14,6 +15,8 @@ from coincurve import PublicKey as Secp256k1PublicKey
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+
+logger = logging.getLogger(__name__)
 
 _NIP44_VERSION = 2
 _NONCE_LEN = 32

--- a/src/aya/identity.py
+++ b/src/aya/identity.py
@@ -224,6 +224,7 @@ class Profile:
 
         Validates profile structure and logs warnings for deprecated keys or malformed data.
         """
+        logger.debug("Loading profile from %s", path)
         data = json.loads(path.read_text())
         # Migrate profiles written by older versions (assistant_sync → aya)
         aya_data = data.get("aya") or data.get("assistant_sync", {})
@@ -323,6 +324,7 @@ class Profile:
 
     def save(self, path: Path) -> None:
         """Write aya fields back into the profile without clobbering other keys."""
+        logger.debug("Saving profile to %s", path)
         data = json.loads(path.read_text()) if path.exists() else {}
         # Drop legacy key on first save with new format
         data.pop("assistant_sync", None)

--- a/src/aya/install.py
+++ b/src/aya/install.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import json
+import logging
 import shutil
 import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 # ── Constants ────────────────────────────────────────────────────────────────
 

--- a/src/aya/packet.py
+++ b/src/aya/packet.py
@@ -214,7 +214,7 @@ class Packet(BaseModel):
         if packet.version and "/" in packet.version:
             major = packet.version.split("/")[1].split(".")[0]
             if major != PROTOCOL_VERSION.split("/")[1].split(".", maxsplit=1)[0]:
-                logging.getLogger(__name__).warning(
+                logger.warning(
                     "Unknown protocol major version: %s (expected %s)",
                     packet.version,
                     PROTOCOL_VERSION,

--- a/src/aya/paths.py
+++ b/src/aya/paths.py
@@ -9,8 +9,11 @@ defined here — those belong to the notebook repo, not to aya.
 
 from __future__ import annotations
 
+import logging
 import os
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 _aya_home_env = os.environ.get("AYA_HOME")
 AYA_HOME = Path(_aya_home_env).expanduser() if _aya_home_env else Path.home() / ".aya"

--- a/src/aya/profile.py
+++ b/src/aya/profile.py
@@ -6,11 +6,14 @@ Canonical location: ~/.aya/profile.json
 from __future__ import annotations
 
 import json
+import logging
 from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
 from aya.paths import PROFILE_PATH
+
+logger = logging.getLogger(__name__)
 
 REEVALUATION_DAYS = 3
 

--- a/src/aya/relay.py
+++ b/src/aya/relay.py
@@ -146,6 +146,7 @@ class RelayClient:
             # In sync context: asyncio.run()
             event_id = asyncio.run(client.publish(packet, recipient_pubkey))
         """
+        logger.debug("Publishing packet %s to %d relay(s)", packet.id[:8], len(self._relay_urls))
         event = self._build_event(packet, recipient_nostr_pubkey, encrypt=encrypt)
         errors: list[str] = []
         last_event_id: str | None = None
@@ -158,6 +159,7 @@ class RelayClient:
                 errors.append(relay_url)
 
         if last_event_id is not None:
+            logger.debug("Packet %s published as event %s", packet.id[:8], last_event_id[:8])
             return last_event_id
 
         raise RelayError(f"All relays rejected the event: {errors}")
@@ -233,12 +235,14 @@ class RelayClient:
                 return packets
             packets = asyncio.run(fetch_all())
         """
+        logger.debug("Fetching pending packets from %d relay(s)", len(self._relay_urls))
         seen_ids: set[str] = set()
         for relay_url in self._relay_urls:
             async for packet in self._fetch_from_relay(relay_url, since):
                 if packet.id not in seen_ids:
                     seen_ids.add(packet.id)
                     yield packet
+        logger.debug("Fetch complete, %d unique packet(s) found", len(seen_ids))
 
     async def _fetch_from_relay(
         self,
@@ -289,6 +293,7 @@ class RelayClient:
             for attempt in range(_MAX_RETRIES_FETCH):
                 page_events = []
                 try:
+                    logger.debug("Connecting to %s (page cursor until=%s)", relay_url, until)
                     async with websockets.connect(relay_url) as ws:
                         await ws.send(json.dumps(["REQ", sub_id, filter_]))
                         try:

--- a/src/aya/status.py
+++ b/src/aya/status.py
@@ -23,6 +23,8 @@ from aya.scheduler import (
     load_items,
 )
 
+logger = logging.getLogger(__name__)
+
 # ── aya data paths (from ~/.aya) ────────────────────────────────────────────
 PROFILE = _paths.PROFILE_PATH
 
@@ -164,7 +166,7 @@ def _gather_status() -> dict[str, Any]:
         active_watches = get_active_watches()
     except (FileNotFoundError, json.JSONDecodeError, OSError, KeyError) as e:
         # Log scheduler fetch failures but don't crash — mark scheduler check failed
-        logging.warning("Failed to load scheduler status: %s", e)
+        logger.warning("Failed to load scheduler status: %s", e)
         scheduler_ok = False
 
     # Add synthetic check for scheduler data integrity


### PR DESCRIPTION
## Summary

- Add `logger = logging.getLogger(__name__)` to 8 modules missing it: `ci.py`, `config.py`, `context.py`, `encryption.py`, `install.py`, `paths.py`, `profile.py`, `status.py`
- Fix `packet.py` inline `logging.getLogger(__name__).warning()` to use the existing module-level `logger`
- Fix `status.py` bare `logging.warning()` to use module-level `logger`
- Add `--verbose` / `-v` flag to CLI via `@app.callback()` — sets `DEBUG` level when enabled, `WARNING` by default
- Add strategic debug logs to `relay.py` (connection, publish, fetch lifecycle), `identity.py` (profile load/save), and `cli.py` (command entry for send/receive/dispatch)

Closes #165

## Test plan

- [x] All 543 existing tests pass (`uv run pytest -q`)
- [x] `uv run ruff check src tests` clean
- [ ] Manual: `aya version` works without verbose output
- [ ] Manual: `aya -v status` shows debug lines from identity/scheduler loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)