### PR TITLE
fix(log): use atomic writes + file locking for log_state.json

### DIFF
--- a/src/aya/log.py
+++ b/src/aya/log.py
@@ -32,14 +32,18 @@ _DEDUP_SECONDS = 300  # 5 minutes
 
 # ── state persistence ────────────────────────────────────────────────────────
 
-_LOG_LOCK_FILE = LOG_STATE_FILE.parent / ".log.lock"
+
+def _log_lock_file() -> Path:
+    """Derive lock path from LOG_STATE_FILE at call time (monkeypatch-safe)."""
+    return LOG_STATE_FILE.parent / ".log.lock"
 
 
 @contextmanager
 def _log_lock(*, shared: bool = False) -> Iterator[int]:
     """Acquire an advisory lock scoped to log state (not the scheduler)."""
-    _LOG_LOCK_FILE.parent.mkdir(parents=True, exist_ok=True)
-    fd = os.open(str(_LOG_LOCK_FILE), os.O_RDWR | os.O_CREAT)
+    lock_path = _log_lock_file()
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT)
     try:
         fcntl.flock(fd, fcntl.LOCK_SH if shared else fcntl.LOCK_EX)
         yield fd


### PR DESCRIPTION
## Summary
- Replace plain `write_text`/`read_text` with atomic writes + advisory file locking for `log_state.json`
- Add `_update_state()` for atomic read-modify-write under a single exclusive lock (prevents race in concurrent callers)
- Separate `.log.lock` file so log and scheduler locks don't contend

Closes #179

## Changes
- `src/aya/log.py` — add `_log_lock()`, `_update_state()`, refactor `_load_state()`/`_save_state()` to use locks + `_atomic_write()`

## Test plan
- [x] 24 log tests passing
- [x] 573/573 full suite passing
- [x] Ruff + mypy clean
- [x] Code review: TOCTOU and read-write race addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)