### PR TITLE
fix(cli): aya send validates signature and re-signs local-authored packets

### DIFF
--- a/src/aya/cli.py
+++ b/src/aya/cli.py
@@ -613,6 +613,34 @@ def send(
     relay_urls = [relay] if relay else p.default_relays
     packet = Packet.from_json(packet_file.read_text())
 
+    # Validate the packet's signature before publishing. Two failure modes
+    # to handle separately:
+    #
+    # 1. Signature is missing or invalid AND from_did matches the local
+    #    instance → user authored this packet but didn't sign it (common
+    #    when hand-editing JSON). Re-sign with the local key automatically.
+    #
+    # 2. Signature is missing or invalid AND from_did is someone else →
+    #    refuse. Forwarding an unsigned packet that claims to be from
+    #    another sender would let the relay carry forged-looking data.
+    #    The user must either get the original sender to sign it, or
+    #    rewrite the from_did to match a local instance.
+    if not packet.verify_from_did():
+        if packet.from_did == local.did:
+            packet = packet.sign(local)
+            logger.info("Re-signed packet %s with local instance key", packet.id)
+        else:
+            _emit_error(
+                ErrorCode.INVALID_ARGUMENT,
+                (
+                    f"Packet has missing or invalid signature, and from_did "
+                    f"({packet.from_did[:40]}…) does not match local instance "
+                    f"({local.did[:40]}…). Refusing to forward an unsigned "
+                    f"packet that claims to be from another sender."
+                ),
+                {"packet_id": packet.id, "from_did": packet.from_did},
+            )
+
     if dry_run:
         _output_json(json.loads(packet.to_json()))
         raise typer.Exit(0)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3383,3 +3383,164 @@ class TestDrop:
 
         assert result.exit_code == 0, result.output
         assert "Dropped packet" not in result.output
+
+
+# ── TestSendSignatureValidation ───────────────────────────────────────────────
+
+
+class TestSendSignatureValidation:
+    """Tests for signature validation in `aya send`.
+
+    Three paths:
+      - Missing/invalid signature, from_did matches local → re-sign + send
+      - Missing/invalid signature, from_did is external → reject
+      - Valid signature → pass through unchanged
+    """
+
+    def test_resigns_when_signature_missing_and_local_is_sender(
+        self, profile_with_trusted: Path, tmp_path: Path
+    ) -> None:
+        """Empty-sig packet authored by local instance is auto-signed before send."""
+        p = Profile.load(profile_with_trusted)
+        local = p.instances["default"]
+        home_key = p.trusted_keys["home"]
+
+        pkt = Packet(
+            **{"from": local.did, "to": home_key.did},
+            intent="hand-edited packet",
+            content="hello",
+        )
+        # Note: no .sign() call — signature is None
+        assert pkt.signature is None
+        packet_file = tmp_path / "packet.json"
+        packet_file.write_text(pkt.to_json())
+
+        captured: dict = {}
+
+        async def fake_publish(packet, *args, **kwargs):
+            captured["packet"] = packet
+            return "e" * 64
+
+        with patch("aya.cli.RelayClient") as mock_cls:
+            mock_cls.return_value.publish = fake_publish
+            result = runner.invoke(
+                app,
+                ["send", str(packet_file), "--profile", str(profile_with_trusted)],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert captured["packet"].signature is not None
+        # And the freshly applied signature is valid
+        assert captured["packet"].verify_from_did()
+
+    def test_resigns_when_signature_invalid_and_local_is_sender(
+        self, profile_with_trusted: Path, tmp_path: Path
+    ) -> None:
+        """Garbage-sig packet authored by local instance is auto-resigned."""
+        p = Profile.load(profile_with_trusted)
+        local = p.instances["default"]
+        home_key = p.trusted_keys["home"]
+
+        pkt = Packet(
+            **{"from": local.did, "to": home_key.did},
+            intent="bad sig packet",
+            content="hello",
+        )
+        # Inject a bogus base64 signature so verify_from_did() returns False
+        pkt.signature = "A" * 100
+        assert not pkt.verify_from_did()
+        packet_file = tmp_path / "packet.json"
+        packet_file.write_text(pkt.to_json())
+
+        captured: dict = {}
+
+        async def fake_publish(packet, *args, **kwargs):
+            captured["packet"] = packet
+            return "e" * 64
+
+        with patch("aya.cli.RelayClient") as mock_cls:
+            mock_cls.return_value.publish = fake_publish
+            result = runner.invoke(
+                app,
+                ["send", str(packet_file), "--profile", str(profile_with_trusted)],
+            )
+
+        assert result.exit_code == 0, result.output
+        # Signature replaced with a valid one
+        assert captured["packet"].verify_from_did()
+
+    def test_rejects_when_signature_missing_and_sender_is_external(
+        self, profile_with_trusted: Path, tmp_path: Path
+    ) -> None:
+        """Empty-sig packet claiming to be from a different sender is refused."""
+        p = Profile.load(profile_with_trusted)
+        home_key = p.trusted_keys["home"]
+        other_sender = Identity.generate("offline")
+
+        pkt = Packet(
+            **{"from": other_sender.did, "to": home_key.did},
+            intent="forged-looking packet",
+            content="hello",
+        )
+        assert pkt.signature is None
+        packet_file = tmp_path / "packet.json"
+        packet_file.write_text(pkt.to_json())
+
+        publish_calls = 0
+
+        async def fake_publish(*args, **kwargs):
+            nonlocal publish_calls
+            publish_calls += 1
+            return "e" * 64
+
+        with patch("aya.cli.RelayClient") as mock_cls:
+            mock_cls.return_value.publish = fake_publish
+            result = runner.invoke(
+                app,
+                [
+                    "send",
+                    str(packet_file),
+                    "--profile",
+                    str(profile_with_trusted),
+                    "--format",
+                    "json",
+                ],
+            )
+
+        assert result.exit_code != 0
+        assert publish_calls == 0  # never reached the relay
+
+    def test_passes_through_valid_signature(
+        self, profile_with_trusted: Path, tmp_path: Path
+    ) -> None:
+        """Properly-signed packet sends without modification."""
+        p = Profile.load(profile_with_trusted)
+        local = p.instances["default"]
+        home_key = p.trusted_keys["home"]
+
+        pkt = Packet(
+            **{"from": local.did, "to": home_key.did},
+            intent="properly signed",
+            content="hello",
+        ).sign(local)
+        original_sig = pkt.signature
+        assert pkt.verify_from_did()
+        packet_file = tmp_path / "packet.json"
+        packet_file.write_text(pkt.to_json())
+
+        captured: dict = {}
+
+        async def fake_publish(packet, *args, **kwargs):
+            captured["packet"] = packet
+            return "e" * 64
+
+        with patch("aya.cli.RelayClient") as mock_cls:
+            mock_cls.return_value.publish = fake_publish
+            result = runner.invoke(
+                app,
+                ["send", str(packet_file), "--profile", str(profile_with_trusted)],
+            )
+
+        assert result.exit_code == 0, result.output
+        # Signature unchanged — pass-through, not re-signed
+        assert captured["packet"].signature == original_sig


### PR DESCRIPTION
## Summary

Closes inbox follow-up **#1** from the relay skill collab session: \`aya send\` was passing packets with empty or invalid signatures through to the relay untouched, surfacing as \`InvalidSignature\` warnings on the receiving instance.

## What changed

\`aya send\` now validates the packet signature at the send boundary via \`packet.verify_from_did()\`. Three paths:

1. **Empty/invalid signature, \`from_did\` matches local instance** → auto re-sign with the local key. Common case: user hand-edited the packet JSON and forgot to call \`sign()\`. The local instance is the rightful sender, so signing on their behalf is what they wanted.

2. **Empty/invalid signature, \`from_did\` is external** → reject with \`INVALID_ARGUMENT\`. Forwarding an unsigned packet that claims to be from another sender would let the relay carry forged-looking data. The user must either get the original sender to sign it, or rewrite \`from_did\` to match a local instance.

3. **Valid signature** → pass through untouched. Allows sending packets signed elsewhere (offline machine, other workflow) without the local instance overwriting them.

## Background

Discovered during the OOO Home Packet exchange on 2026-04-11. Work-side hand-crafted a packet JSON with \`"signature": ""\` and ran \`aya send\`; the empty-sig packet shipped to the relay and home rejected it. The fix automates the resign step for the common case and refuses the dangerous case.

## Test plan

- [x] 4 new tests in \`TestSendSignatureValidation\` covering: missing-sig + local sender → resign, invalid-sig + local sender → resign, missing-sig + external sender → reject, valid sig → pass-through
- [x] Existing 8 \`send\` tests still pass (the auto-resign path doesn't break the dry-run / idempotency / error tests)
- [x] Full suite: 617 pass, lint + format + mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)