### PR TITLE
fix(scheduler): mid-session recurring crons now fire via PostToolUse hook

### DIFF
--- a/src/aya/cli.py
+++ b/src/aya/cli.py
@@ -1989,26 +1989,69 @@ def schedule_uninstall(
 
 
 @hook_app.command("crons")
-def hook_crons() -> None:
-    """Output CronCreate instructions for Claude Code SessionStart hooks.
+def hook_crons(
+    reset: bool = typer.Option(
+        False,
+        "--reset",
+        help=(
+            "Clear the per-session registered-crons tracker before emitting. "
+            "Use at SessionStart so a fresh session re-registers everything."
+        ),
+    ),
+    event: str = typer.Option(
+        "SessionStart",
+        "--event",
+        help=(
+            "Hook event name to use in the emitted hookSpecificOutput JSON. "
+            "Defaults to SessionStart for the SessionStart hook entry; "
+            "PostToolUse hook should pass --event PostToolUse so the "
+            "additionalContext is delivered after the tool result."
+        ),
+    ),
+) -> None:
+    """Output CronCreate instructions for Claude Code hooks.
 
     Reads active session crons from the scheduler and emits a JSON
     hookSpecificOutput block that tells Claude Code to register them
-    via CronCreate.  Exits silently when there are no crons to register.
+    via CronCreate. Exits silently when there are no NEW crons to
+    register.
+
+    Tracks already-registered cron IDs in
+    ``~/.aya/session_registered_crons.json`` so a follow-up call only
+    emits crons that haven't been seen yet in the current session. This
+    is what makes mid-session ``aya schedule recurring`` calls actually
+    fire — the PostToolUse hook re-runs ``aya hook crons`` on the next
+    tool boundary, the new cron isn't in the tracker, and it gets
+    registered just like a SessionStart cron would.
 
     Unlike get_pending(), this does NOT claim alerts — safe to run before
     ``aya schedule pending`` without consuming alerts.
 
     Usage in ~/.claude/settings.json:
-        {"command": "aya hook crons", "statusMessage": "Registering crons..."}
+        SessionStart: ``aya hook crons --reset``
+        PostToolUse:  ``aya hook crons --event PostToolUse``
     """
+    from aya.scheduler import (
+        load_registered_cron_ids,
+        reset_registered_cron_ids,
+        save_registered_cron_ids,
+    )
+
+    if reset:
+        reset_registered_cron_ids()
+
     crons, _suppressed = get_session_crons()
     if not crons:
         return
 
-    # Emit one hookSpecificOutput per cron so each gets its own system
+    already_registered = load_registered_cron_ids()
+    new_crons = [c for c in crons if c.get("id", "") not in already_registered]
+    if not new_crons:
+        return
+
+    # Emit one hookSpecificOutput per new cron so each gets its own system
     # reminder and can't be truncated when multiple crons are bundled.
-    for c in crons:
+    for c in new_crons:
         cid = c.get("id", "")
         schedule = c.get("cron", "")
         prompt = c.get("prompt") or c.get("message") or c.get("description") or ""
@@ -2022,12 +2065,17 @@ def hook_crons() -> None:
             json.dumps(
                 {
                     "hookSpecificOutput": {
-                        "hookEventName": "SessionStart",
+                        "hookEventName": event,
                         "additionalContext": context,
                     }
                 }
             )
         )
+
+    # Persist the IDs we just emitted so the next call (e.g. via the
+    # PostToolUse hook) doesn't double-register them.
+    updated_ids = already_registered | {c.get("id", "") for c in new_crons if c.get("id")}
+    save_registered_cron_ids(updated_ids)
 
 
 # ── ci ────────────────────────────────────────────────────────────────────────

--- a/src/aya/install.py
+++ b/src/aya/install.py
@@ -34,7 +34,7 @@ CANONICAL_HOOKS: dict[str, list[dict[str, Any]]] = {
             "hooks": [
                 {
                     "type": "command",
-                    "command": "aya hook crons",
+                    "command": "aya hook crons --reset",
                     "statusMessage": "Registering crons...",
                 }
             ]
@@ -72,6 +72,15 @@ CANONICAL_HOOKS: dict[str, list[dict[str, Any]]] = {
         },
     ],
     "PostToolUse": [
+        {
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": "aya hook crons --event PostToolUse 2>/dev/null || true",
+                    "statusMessage": "",
+                }
+            ]
+        },
         {
             "matcher": "Bash",
             "hooks": [

--- a/src/aya/scheduler/__init__.py
+++ b/src/aya/scheduler/__init__.py
@@ -98,6 +98,7 @@ from .storage import (
     _new_id,
     _parse_tags,
     _scheduler_file,
+    _registered_crons_file,
     _session_lock_file,
     claim_alert,
     clear_session_lock,
@@ -106,8 +107,11 @@ from .storage import (
     is_session_active,
     load_alerts,
     load_items,
+    load_registered_cron_ids,
+    reset_registered_cron_ids,
     save_alerts,
     save_items,
+    save_registered_cron_ids,
     sweep_stale_claims,
     write_session_lock,
 )
@@ -182,6 +186,7 @@ _LAZY_ATTRS: dict[str, Any] = {
     "LOCK_FILE": lambda: _lock_file(),  # noqa: PLW0108 — forward ref
     "CLAIMS_DIR": lambda: _claims_dir(),  # noqa: PLW0108 — forward ref
     "SESSION_LOCK_FILE": lambda: _session_lock_file(),  # noqa: PLW0108 — forward ref
+    "REGISTERED_CRONS_FILE": lambda: _registered_crons_file(),  # noqa: PLW0108
     "LOCAL_TZ": _get_local_tz,
 }
 
@@ -242,6 +247,7 @@ __all__ = [
     "LOCK_FILE",
     "CLAIMS_DIR",
     "SESSION_LOCK_FILE",
+    "REGISTERED_CRONS_FILE",
     "LOCAL_TZ",
     # Core functions
     "add_reminder",
@@ -276,7 +282,11 @@ __all__ = [
     "write_session_lock",
     "clear_session_lock",
     "is_session_active",
+    "_registered_crons_file",
     "_session_lock_file",
+    "load_registered_cron_ids",
+    "save_registered_cron_ids",
+    "reset_registered_cron_ids",
     "_passes_severity_filter",
     # Display
     "show_alerts",

--- a/src/aya/scheduler/storage.py
+++ b/src/aya/scheduler/storage.py
@@ -448,3 +448,69 @@ def is_session_active() -> bool:
         is_active,
     )
     return is_active
+
+
+# ── per-session registered crons tracker ───────────────────────────────────
+#
+# `aya hook crons` reads active session crons and emits hookSpecificOutput
+# JSON instructing Claude Code to register them via CronCreate. To support
+# mid-session registration (i.e. running `aya schedule recurring` after
+# the session has already started), we track which cron IDs have already
+# been emitted within the current session, so a follow-up call only emits
+# the newly created ones.
+#
+# The tracker is reset at SessionStart via `aya hook crons --reset`, and
+# is consulted (without reset) by the PostToolUse hook entry to surface
+# any newly-created crons on the next tool boundary.
+
+
+def _registered_crons_file() -> Path:
+    """Return the per-session registered crons tracker file path.
+
+    Honors a package-level override (``REGISTERED_CRONS_FILE``) so tests
+    can redirect the path without touching ``AYA_HOME``.
+    """
+    pkg = _get_package_globals()
+    if "REGISTERED_CRONS_FILE" in pkg and pkg["REGISTERED_CRONS_FILE"] is not None:
+        val = pkg["REGISTERED_CRONS_FILE"]
+        if isinstance(val, Path):
+            return val
+    return _paths.AYA_HOME / "session_registered_crons.json"
+
+
+def load_registered_cron_ids() -> set[str]:
+    """Return the set of cron IDs already registered in this session."""
+    path = _registered_crons_file()
+    if not path.exists():
+        return set()
+    try:
+        data = json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return set()
+    if not isinstance(data, dict):
+        return set()
+    raw_ids = data.get("ids", [])
+    if not isinstance(raw_ids, list):
+        return set()
+    return {pid for pid in raw_ids if isinstance(pid, str)}
+
+
+def save_registered_cron_ids(ids: set[str]) -> None:
+    """Persist the set of cron IDs registered in this session."""
+    path = _registered_crons_file()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "updated_at": datetime.now(_get_local_tz()).isoformat(),
+        "ids": sorted(ids),
+    }
+    _atomic_write(path, payload)
+
+
+def reset_registered_cron_ids() -> None:
+    """Clear the per-session registered crons tracker.
+
+    Called at SessionStart so a fresh session re-registers everything.
+    """
+    path = _registered_crons_file()
+    if path.exists():
+        path.unlink(missing_ok=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -892,15 +892,32 @@ def _isolate_scheduler(tmp_path, monkeypatch):
 
 @pytest.mark.usefixtures("_isolate_scheduler")
 class TestHookCrons:
-    def test_no_crons_exits_silently(self):
+    @pytest.fixture
+    def isolated_scheduler(self, tmp_path, monkeypatch):
+        """Patch SCHEDULER_FILE, ALERTS_FILE, and REGISTERED_CRONS_FILE to a tmp dir.
+
+        Without REGISTERED_CRONS_FILE patching the tests would leak writes to
+        the real ~/.aya/session_registered_crons.json across the test suite.
+        """
+        sched_dir = tmp_path / "sched"
+        sched_dir.mkdir()
+        scheduler_file = sched_dir / "scheduler.json"
+        alerts_file = sched_dir / "alerts.json"
+        registered_file = sched_dir / "session_registered_crons.json"
+        scheduler_file.write_text(json.dumps({"items": []}))
+        alerts_file.write_text(json.dumps({"alerts": []}))
+        monkeypatch.setattr("aya.scheduler.SCHEDULER_FILE", scheduler_file)
+        monkeypatch.setattr("aya.scheduler.ALERTS_FILE", alerts_file)
+        monkeypatch.setattr("aya.scheduler.REGISTERED_CRONS_FILE", registered_file)
+        return sched_dir
+
+    def test_no_crons_exits_silently(self, isolated_scheduler):
         result = runner.invoke(app, ["hook", "crons"])
         assert result.exit_code == 0
         assert result.output.strip() == ""
 
-    def test_outputs_valid_json_with_crons(self, tmp_path, monkeypatch):
-        scheduler_file = tmp_path / "sched" / "scheduler.json"
-        alerts_file = tmp_path / "sched" / "alerts.json"
-        scheduler_file.parent.mkdir(parents=True)
+    def test_outputs_valid_json_with_crons(self, isolated_scheduler):
+        scheduler_file = isolated_scheduler / "scheduler.json"
         scheduler_file.write_text(
             json.dumps(
                 {
@@ -919,9 +936,6 @@ class TestHookCrons:
                 }
             )
         )
-        alerts_file.write_text(json.dumps({"alerts": []}))
-        monkeypatch.setattr("aya.scheduler.SCHEDULER_FILE", scheduler_file)
-        monkeypatch.setattr("aya.scheduler.ALERTS_FILE", alerts_file)
 
         result = runner.invoke(app, ["hook", "crons"])
         assert result.exit_code == 0
@@ -931,13 +945,11 @@ class TestHookCrons:
         assert "CronCreate" in ctx
         assert "test-cron" in ctx
 
-    def test_multiple_crons_emit_separate_lines(self, tmp_path, monkeypatch):
+    def test_multiple_crons_emit_separate_lines(self, isolated_scheduler):
         """Each session cron must produce its own JSON line so Claude Code
         creates a separate system reminder per cron — prevents truncation
         when multiple crons are bundled into a single hookSpecificOutput."""
-        scheduler_file = tmp_path / "sched" / "scheduler.json"
-        alerts_file = tmp_path / "sched" / "alerts.json"
-        scheduler_file.parent.mkdir(parents=True)
+        scheduler_file = isolated_scheduler / "scheduler.json"
         scheduler_file.write_text(
             json.dumps(
                 {
@@ -966,9 +978,6 @@ class TestHookCrons:
                 }
             )
         )
-        alerts_file.write_text(json.dumps({"alerts": []}))
-        monkeypatch.setattr("aya.scheduler.SCHEDULER_FILE", scheduler_file)
-        monkeypatch.setattr("aya.scheduler.ALERTS_FILE", alerts_file)
 
         result = runner.invoke(app, ["hook", "crons"])
         assert result.exit_code == 0
@@ -990,11 +999,9 @@ class TestHookCrons:
 
         assert ids == {"cron-health", "cron-relay"}, f"Missing cron IDs: {ids}"
 
-    def test_escapes_double_quotes_in_prompt(self, tmp_path, monkeypatch):
+    def test_escapes_double_quotes_in_prompt(self, isolated_scheduler):
         """Prompts with double quotes must be escaped to avoid malformed output."""
-        scheduler_file = tmp_path / "sched" / "scheduler.json"
-        alerts_file = tmp_path / "sched" / "alerts.json"
-        scheduler_file.parent.mkdir(parents=True)
+        scheduler_file = isolated_scheduler / "scheduler.json"
         scheduler_file.write_text(
             json.dumps(
                 {
@@ -1013,9 +1020,6 @@ class TestHookCrons:
                 }
             )
         )
-        alerts_file.write_text(json.dumps({"alerts": []}))
-        monkeypatch.setattr("aya.scheduler.SCHEDULER_FILE", scheduler_file)
-        monkeypatch.setattr("aya.scheduler.ALERTS_FILE", alerts_file)
 
         result = runner.invoke(app, ["hook", "crons"])
         assert result.exit_code == 0
@@ -1026,12 +1030,9 @@ class TestHookCrons:
         # Must not contain unescaped quotes that would break parsing
         assert 'prompt="Say \\"hello\\" to the user."' in ctx
 
-    def test_does_not_claim_alerts(self, tmp_path, monkeypatch):
+    def test_does_not_claim_alerts(self, isolated_scheduler):
         """hook crons must not consume alerts — they belong to schedule pending."""
-        scheduler_file = tmp_path / "sched" / "scheduler.json"
-        alerts_file = tmp_path / "sched" / "alerts.json"
-        scheduler_file.parent.mkdir(parents=True)
-        scheduler_file.write_text(json.dumps({"items": []}))
+        alerts_file = isolated_scheduler / "alerts.json"
         alerts_file.write_text(
             json.dumps(
                 {
@@ -1048,8 +1049,6 @@ class TestHookCrons:
                 }
             )
         )
-        monkeypatch.setattr("aya.scheduler.SCHEDULER_FILE", scheduler_file)
-        monkeypatch.setattr("aya.scheduler.ALERTS_FILE", alerts_file)
 
         # Run hook crons
         runner.invoke(app, ["hook", "crons"])
@@ -1059,6 +1058,159 @@ class TestHookCrons:
         assert len(alerts) == 1
         assert alerts[0]["seen"] is False
         assert "delivered_at" not in alerts[0]
+
+    def test_second_call_emits_nothing_when_already_registered(self, isolated_scheduler):
+        """The mid-session re-registration guard: hook crons should track
+        which IDs it has emitted and skip them on subsequent calls."""
+        scheduler_file = isolated_scheduler / "scheduler.json"
+        scheduler_file.write_text(
+            json.dumps(
+                {
+                    "items": [
+                        {
+                            "id": "tracker-cron",
+                            "type": "recurring",
+                            "status": "active",
+                            "created_at": "2026-01-01T00:00:00-07:00",
+                            "message": "test",
+                            "session_required": True,
+                            "cron": "* * * * *",
+                            "prompt": "Tick.",
+                        }
+                    ]
+                }
+            )
+        )
+
+        first = runner.invoke(app, ["hook", "crons"])
+        assert first.exit_code == 0
+        assert "tracker-cron" in first.output
+
+        second = runner.invoke(app, ["hook", "crons"])
+        assert second.exit_code == 0
+        assert second.output.strip() == ""  # already registered, nothing new
+
+    def test_reset_flag_clears_tracker_and_re_emits(self, isolated_scheduler):
+        """--reset (used at SessionStart) should clear the tracker so a fresh
+        session re-registers everything from scratch."""
+        scheduler_file = isolated_scheduler / "scheduler.json"
+        scheduler_file.write_text(
+            json.dumps(
+                {
+                    "items": [
+                        {
+                            "id": "reset-cron",
+                            "type": "recurring",
+                            "status": "active",
+                            "created_at": "2026-01-01T00:00:00-07:00",
+                            "message": "test",
+                            "session_required": True,
+                            "cron": "* * * * *",
+                            "prompt": "Tick.",
+                        }
+                    ]
+                }
+            )
+        )
+
+        first = runner.invoke(app, ["hook", "crons"])
+        assert "reset-cron" in first.output
+
+        second = runner.invoke(app, ["hook", "crons", "--reset"])
+        assert second.exit_code == 0
+        # After --reset the tracker is empty, so the cron is re-emitted
+        assert "reset-cron" in second.output
+
+    def test_new_cron_added_mid_session_is_picked_up(self, isolated_scheduler):
+        """Add a cron after the first hook crons call, then re-run — only
+        the new cron should be emitted on the second call. This is the
+        end-to-end behavior the PostToolUse hook relies on."""
+        scheduler_file = isolated_scheduler / "scheduler.json"
+        scheduler_file.write_text(
+            json.dumps(
+                {
+                    "items": [
+                        {
+                            "id": "old-cron",
+                            "type": "recurring",
+                            "status": "active",
+                            "created_at": "2026-01-01T00:00:00-07:00",
+                            "message": "old",
+                            "session_required": True,
+                            "cron": "* * * * *",
+                            "prompt": "Old.",
+                        }
+                    ]
+                }
+            )
+        )
+
+        first = runner.invoke(app, ["hook", "crons"])
+        assert "old-cron" in first.output
+        assert "new-cron" not in first.output
+
+        # Mid-session: add a new cron
+        scheduler_file.write_text(
+            json.dumps(
+                {
+                    "items": [
+                        {
+                            "id": "old-cron",
+                            "type": "recurring",
+                            "status": "active",
+                            "created_at": "2026-01-01T00:00:00-07:00",
+                            "message": "old",
+                            "session_required": True,
+                            "cron": "* * * * *",
+                            "prompt": "Old.",
+                        },
+                        {
+                            "id": "new-cron",
+                            "type": "recurring",
+                            "status": "active",
+                            "created_at": "2026-01-01T00:00:00-07:00",
+                            "message": "new",
+                            "session_required": True,
+                            "cron": "* * * * *",
+                            "prompt": "New.",
+                        },
+                    ]
+                }
+            )
+        )
+
+        second = runner.invoke(app, ["hook", "crons"])
+        assert second.exit_code == 0
+        assert "new-cron" in second.output
+        assert "old-cron" not in second.output  # already in tracker
+
+    def test_event_flag_changes_hook_event_name(self, isolated_scheduler):
+        """--event PostToolUse routes the additionalContext through the
+        PostToolUse hook channel instead of SessionStart."""
+        scheduler_file = isolated_scheduler / "scheduler.json"
+        scheduler_file.write_text(
+            json.dumps(
+                {
+                    "items": [
+                        {
+                            "id": "event-cron",
+                            "type": "recurring",
+                            "status": "active",
+                            "created_at": "2026-01-01T00:00:00-07:00",
+                            "message": "test",
+                            "session_required": True,
+                            "cron": "* * * * *",
+                            "prompt": "Tick.",
+                        }
+                    ]
+                }
+            )
+        )
+
+        result = runner.invoke(app, ["hook", "crons", "--event", "PostToolUse"])
+        assert result.exit_code == 0
+        data = json.loads(result.output.strip())
+        assert data["hookSpecificOutput"]["hookEventName"] == "PostToolUse"
 
 
 @pytest.mark.usefixtures("_isolate_scheduler")


### PR DESCRIPTION
## Summary

Closes inbox follow-up **#6**: a recurring cron created via \`aya schedule recurring\` *mid-session* would sit dormant until the next SessionStart. The cron was visible in \`aya schedule list\` and \`aya schedule status\`, but Claude Code never registered it via \`CronCreate\` because the registration only happens at SessionStart via \`aya hook crons\`.

## How it works

1. **SessionStart**: \`aya hook crons --reset\` clears the per-session tracker file (\`~/.aya/session_registered_crons.json\`) and emits \`hookSpecificOutput\` for every active session cron.

2. **User runs \`aya schedule recurring\` mid-session**: the cron lands in scheduler.json but isn't yet in the tracker.

3. **Next tool call**: PostToolUse hook fires \`aya hook crons --event PostToolUse\`, reads the tracker, sees the new cron ID isn't in it, emits \`hookSpecificOutput\` → Claude registers via \`CronCreate\`. Cron starts firing same-session.

4. **Subsequent tool calls**: tracker contains the cron ID, re-running is a no-op. No duplicates.

## Implementation

- **Storage** (\`scheduler/storage.py\`): new \`load_registered_cron_ids\`, \`save_registered_cron_ids\`, \`reset_registered_cron_ids\` helpers. The \`_registered_crons_file()\` accessor uses the same package-level override pattern as \`_session_lock_file()\` so tests can redirect the path.

- **CLI** (\`aya hook crons\`):
  - \`--reset\` clears the tracker before emitting (SessionStart use)
  - \`--event NAME\` overrides the \`hookEventName\` in \`hookSpecificOutput\` (defaults \`SessionStart\`; PostToolUse hook passes \`PostToolUse\`)
  - Filters out cron IDs already in the tracker, persists newly-emitted IDs

- **Install** (\`install.py\`):
  - \`SessionStart\` entry now invokes \`aya hook crons --reset\`
  - New \`PostToolUse\` entry runs \`aya hook crons --event PostToolUse 2>/dev/null || true\` on every tool boundary

## Test plan

- [x] 4 new TestHookCrons tests: dedup on second call, \`--reset\` clears + re-emits, mid-session add detection, \`--event\` flag routing
- [x] Refactored existing 5 TestHookCrons tests to share an \`isolated_scheduler\` fixture that also patches \`REGISTERED_CRONS_FILE\` — the previous tests were leaking writes to real \`~/.aya/session_registered_crons.json\` because they only patched \`SCHEDULER_FILE\`/\`ALERTS_FILE\`. Caught while developing the new behavior.
- [x] Full suite: 636 pass, lint + format + mypy clean

## Caveats

Relies on Claude Code's PostToolUse hook firing on every tool call and on \`hookSpecificOutput\` JSON being interpreted in the active session — both are existing Claude Code behaviors, not new aya guarantees. The aya-side logic (tracker, dedup, emission) is fully tested; the end-to-end Claude Code integration is runtime-only.

Existing users will get a \`hooks_updated\` notification on next \`aya schedule install\` since the canonical PostToolUse entry has a new unmatched-matcher hook.

## Closes the open follow-up list

After this PR, all 8 inbox follow-ups from the 2026-04-11 relay skill collab session are addressed:

| # | Status |
|---|---|
| 1 | done — \`aya send\` resign/reject (#196) |
| 2 | done — work's #192 |
| 3 | done — operator error, not a bug |
| 4 | done — \`aya drop\` (#195) |
| 5 | done — \`--tick-interval\` (#197) |
| 6 | **done — this PR** |
| 7 | done — \`aya read\` (#195) |
| 8 | done — \`aya drop\` (#195) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)