### PR TITLE
fix(scheduler): address code review findings on PRs #195-198

### DIFF
--- a/src/aya/cli.py
+++ b/src/aya/cli.py
@@ -2025,11 +2025,7 @@ def hook_crons(
         SessionStart: ``aya hook crons --reset``
         PostToolUse:  ``aya hook crons --event PostToolUse``
     """
-    from aya.scheduler import (
-        load_registered_cron_ids,
-        reset_registered_cron_ids,
-        save_registered_cron_ids,
-    )
+    from aya.scheduler import register_new_cron_ids, reset_registered_cron_ids
 
     if reset:
         reset_registered_cron_ids()
@@ -2038,10 +2034,20 @@ def hook_crons(
     if not crons:
         return
 
-    already_registered = load_registered_cron_ids()
-    new_crons = [c for c in crons if c.get("id", "") not in already_registered]
-    if not new_crons:
+    # Atomically merge candidate cron IDs into the per-session tracker
+    # under a single file lock. The returned set is the IDs that were
+    # NOT previously in the tracker — i.e. the ones we should emit.
+    # Two concurrent processes racing on the same cron will both call
+    # register_new_cron_ids; only the lock winner sees the IDs as new.
+    # The other gets an empty set back and emits nothing. This prevents
+    # duplicate CronCreate registrations when Claude Code dispatches
+    # parallel tool calls and the PostToolUse hook fires concurrently.
+    candidate_ids = {c.get("id", "") for c in crons if c.get("id")}
+    new_ids = register_new_cron_ids(candidate_ids)
+    if not new_ids:
         return
+
+    new_crons = [c for c in crons if c.get("id", "") in new_ids]
 
     # Emit one hookSpecificOutput per new cron so each gets its own system
     # reminder and can't be truncated when multiple crons are bundled.
@@ -2065,11 +2071,6 @@ def hook_crons(
                 }
             )
         )
-
-    # Persist the IDs we just emitted so the next call (e.g. via the
-    # PostToolUse hook) doesn't double-register them.
-    updated_ids = already_registered | {c.get("id", "") for c in new_crons if c.get("id")}
-    save_registered_cron_ids(updated_ids)
 
 
 # ── ci ────────────────────────────────────────────────────────────────────────

--- a/src/aya/install.py
+++ b/src/aya/install.py
@@ -78,6 +78,7 @@ CANONICAL_HOOKS: dict[str, list[dict[str, Any]]] = {
                     "type": "command",
                     "command": "aya hook crons --event PostToolUse 2>/dev/null || true",
                     "statusMessage": "",
+                    "async": True,
                 }
             ]
         },
@@ -248,12 +249,22 @@ def _get_current_crontab() -> str:
     return result.stdout
 
 
+def _is_aya_cron_line(line: str) -> bool:
+    """True if a crontab line is an aya-managed scheduler-tick entry.
+
+    Detection requires the canonical CRON_COMMENT marker (or its
+    sub-minute offset variant ``CRON_COMMENT-30s``). Substring-matching
+    only on ``"aya schedule tick"`` is too aggressive — it would
+    accidentally strip user comments that mention the command (e.g.
+    ``# reminder: investigate aya schedule tick latency``) when
+    rewriting the crontab.
+    """
+    return CRON_COMMENT in line
+
+
 def _has_aya_cron(crontab_text: str) -> bool:
-    """Check if any line contains an aya tick entry."""
-    for line in crontab_text.splitlines():
-        if "aya schedule tick" in line or CRON_COMMENT in line:
-            return True
-    return False
+    """Check if any line is an aya-managed tick entry."""
+    return any(_is_aya_cron_line(line) for line in crontab_text.splitlines())
 
 
 def _add_cron_entry(
@@ -280,11 +291,7 @@ def _add_cron_entry(
 
     # Strip any existing aya entries (force or no — when force, we replace;
     # when not force, _has_aya_cron above returned True so we don't reach here).
-    surviving = [
-        line
-        for line in current.splitlines()
-        if "aya schedule tick" not in line and CRON_COMMENT not in line
-    ]
+    surviving = [line for line in current.splitlines() if not _is_aya_cron_line(line)]
     new_crontab_parts = surviving + cron_lines
     new_crontab = "\n".join(new_crontab_parts) + "\n"
     if not new_crontab.strip():
@@ -308,11 +315,7 @@ def _remove_cron_entry(dry_run: bool = False) -> bool:
     if dry_run:
         return True
 
-    lines = [
-        line
-        for line in current.splitlines()
-        if "aya schedule tick" not in line and CRON_COMMENT not in line
-    ]
+    lines = [line for line in current.splitlines() if not _is_aya_cron_line(line)]
     new_crontab = "\n".join(lines) + "\n" if lines else ""
 
     if new_crontab.strip():

--- a/src/aya/scheduler/__init__.py
+++ b/src/aya/scheduler/__init__.py
@@ -113,6 +113,7 @@ from .storage import (
     load_alerts,
     load_items,
     load_registered_cron_ids,
+    register_new_cron_ids,
     reset_registered_cron_ids,
     save_alerts,
     save_items,
@@ -299,6 +300,7 @@ __all__ = [
     "_session_lock_file",
     "load_registered_cron_ids",
     "save_registered_cron_ids",
+    "register_new_cron_ids",
     "reset_registered_cron_ids",
     "_passes_severity_filter",
     # Display

--- a/src/aya/scheduler/storage.py
+++ b/src/aya/scheduler/storage.py
@@ -478,8 +478,13 @@ def _registered_crons_file() -> Path:
     return _paths.AYA_HOME / "session_registered_crons.json"
 
 
-def load_registered_cron_ids() -> set[str]:
-    """Return the set of cron IDs already registered in this session."""
+def _load_registered_cron_ids_unlocked() -> set[str]:
+    """Read the registered-crons tracker from disk without acquiring the lock.
+
+    Caller must already hold an exclusive ``_file_lock()`` if they intend
+    to write afterwards. Use ``load_registered_cron_ids()`` for read-only
+    access.
+    """
     path = _registered_crons_file()
     if not path.exists():
         return set()
@@ -495,8 +500,11 @@ def load_registered_cron_ids() -> set[str]:
     return {pid for pid in raw_ids if isinstance(pid, str)}
 
 
-def save_registered_cron_ids(ids: set[str]) -> None:
-    """Persist the set of cron IDs registered in this session."""
+def _save_registered_cron_ids_unlocked(ids: set[str]) -> None:
+    """Write the registered-crons tracker to disk without acquiring the lock.
+
+    Caller must already hold an exclusive ``_file_lock()``.
+    """
     path = _registered_crons_file()
     path.parent.mkdir(parents=True, exist_ok=True)
     payload = {
@@ -506,11 +514,59 @@ def save_registered_cron_ids(ids: set[str]) -> None:
     _atomic_write(path, payload)
 
 
+def load_registered_cron_ids() -> set[str]:
+    """Return the set of cron IDs already registered in this session.
+
+    Read-only snapshot. For atomic check-and-update use
+    ``register_new_cron_ids()``.
+    """
+    with _file_lock(shared=True):
+        return _load_registered_cron_ids_unlocked()
+
+
+def save_registered_cron_ids(ids: set[str]) -> None:
+    """Persist the set of cron IDs registered in this session.
+
+    Acquires the file lock to avoid races with concurrent readers/writers.
+    For check-and-update from a known-empty starting state use
+    ``register_new_cron_ids()`` which is atomic across the load-merge-save
+    cycle.
+    """
+    with _file_lock():
+        _save_registered_cron_ids_unlocked(ids)
+
+
+def register_new_cron_ids(candidate_ids: set[str]) -> set[str]:
+    """Atomically merge ``candidate_ids`` into the per-session tracker.
+
+    Returns the subset of ``candidate_ids`` that were NOT previously in
+    the tracker — i.e. the IDs the caller should emit as new
+    registrations. The tracker is updated to include all candidates
+    before this function returns, so a subsequent concurrent call sees
+    them as already-registered and emits nothing.
+
+    The entire load → merge → save sequence runs under a single
+    exclusive ``_file_lock()`` so two concurrent processes can't both
+    decide an ID is new and double-emit it. This matters because the
+    PostToolUse ``aya hook crons`` hook fires on every tool use, and
+    Claude Code dispatches tool calls in parallel.
+    """
+    if not candidate_ids:
+        return set()
+    with _file_lock():
+        existing = _load_registered_cron_ids_unlocked()
+        new = candidate_ids - existing
+        if new:
+            _save_registered_cron_ids_unlocked(existing | candidate_ids)
+        return new
+
+
 def reset_registered_cron_ids() -> None:
     """Clear the per-session registered crons tracker.
 
     Called at SessionStart so a fresh session re-registers everything.
     """
-    path = _registered_crons_file()
-    if path.exists():
-        path.unlink(missing_ok=True)
+    with _file_lock():
+        path = _registered_crons_file()
+        if path.exists():
+            path.unlink(missing_ok=True)

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -84,16 +84,33 @@ class TestIsAyaCommand:
 
 
 class TestHasAyaCron:
-    def test_present_by_command(self) -> None:
-        crontab = "*/5 * * * * /home/user/.local/bin/aya schedule tick --quiet\n"
+    def test_present_by_canonical_marker(self) -> None:
+        # Real aya-emitted lines always include CRON_COMMENT.
+        crontab = f"*/5 * * * * /home/user/.local/bin/aya schedule tick --quiet  {CRON_COMMENT}\n"
         assert _has_aya_cron(crontab) is True
 
-    def test_present_by_comment(self) -> None:
+    def test_present_by_marker_only(self) -> None:
+        # Even minimal lines that contain the marker are detected.
         crontab = f"*/10 * * * * /some/path/to/aya tick  {CRON_COMMENT}\n"
         assert _has_aya_cron(crontab) is True
 
-    def test_absent(self) -> None:
+    def test_absent_unrelated_line(self) -> None:
         crontab = "0 * * * * /usr/bin/backup.sh\n"
+        assert _has_aya_cron(crontab) is False
+
+    def test_absent_user_comment_mentioning_aya(self) -> None:
+        # Detection must NOT be substring-matched on "aya schedule tick" —
+        # user comments mentioning the command shouldn't be misclassified
+        # as aya entries (and then stripped on rewrite).
+        crontab = "# reminder: investigate aya schedule tick latency\n"
+        assert _has_aya_cron(crontab) is False
+
+    def test_absent_unmarked_legacy_line(self) -> None:
+        # A bare `aya schedule tick` line without the canonical comment
+        # is NOT detected. This is intentional — back-compat for users
+        # with very old aya entries is sacrificed for safety against
+        # false positives. Such users would need to re-run install.
+        crontab = "*/5 * * * * /usr/local/bin/aya schedule tick --quiet\n"
         assert _has_aya_cron(crontab) is False
 
     def test_empty(self) -> None:
@@ -140,6 +157,27 @@ class TestBuildCronLines:
         # */60 is invalid cron syntax; we emit "0 * * * *" instead
         assert lines[0].startswith("0 * * * *")
         assert "*/60" not in lines[0]
+
+
+class TestCanonicalHookEntries:
+    """Lock-in tests for hook entries that have specific async/sync requirements."""
+
+    def test_post_tool_use_hook_crons_is_async(self) -> None:
+        """The PostToolUse `aya hook crons` entry must be async — every tool
+        call would otherwise pay a Python interpreter cold-start, blocking
+        the next tool. The sibling `aya log auto` and `aya hook watch`
+        entries are also async; the crons entry must match."""
+        post_tool_use = CANONICAL_HOOKS["PostToolUse"]
+        crons_entries = [
+            h
+            for entry in post_tool_use
+            for h in entry.get("hooks", [])
+            if "aya hook crons" in h.get("command", "")
+        ]
+        assert len(crons_entries) == 1, "Expected exactly one `aya hook crons` PostToolUse hook"
+        assert crons_entries[0].get("async") is True, (
+            "PostToolUse `aya hook crons` must have `async: True` — see PR review of #198"
+        )
 
 
 class TestParseTickInterval:
@@ -337,7 +375,7 @@ class TestInstallCron:
         assert "aya schedule tick" in written[0]
 
     def test_already_present(self, tmp_path: Path) -> None:
-        existing = "*/5 * * * * /usr/local/bin/aya schedule tick --quiet\n"
+        existing = f"*/5 * * * * /usr/local/bin/aya schedule tick --quiet  {CRON_COMMENT}\n"
 
         def mock_run(cmd, **kwargs):
             if cmd == ["crontab", "-l"]:

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -37,12 +37,16 @@ def _isolate_scheduler(tmp_path, monkeypatch):
     """Point scheduler at a temp directory so tests don't touch real data."""
     scheduler_file = tmp_path / "assistant" / "memory" / "scheduler.json"
     alerts_file = tmp_path / "assistant" / "memory" / "alerts.json"
+    registered_file = tmp_path / "assistant" / "memory" / "session_registered_crons.json"
+    lock_file = tmp_path / "assistant" / "memory" / ".scheduler.lock"
     scheduler_file.parent.mkdir(parents=True)
     scheduler_file.write_text(json.dumps({"items": []}))
     alerts_file.write_text(json.dumps({"alerts": []}))
 
     monkeypatch.setattr("aya.scheduler.SCHEDULER_FILE", scheduler_file)
     monkeypatch.setattr("aya.scheduler.ALERTS_FILE", alerts_file)
+    monkeypatch.setattr("aya.scheduler.REGISTERED_CRONS_FILE", registered_file)
+    monkeypatch.setattr("aya.scheduler.LOCK_FILE", lock_file)
 
 
 # ── Timezone configuration ──────────────────────────────────────────────────────
@@ -614,3 +618,105 @@ class TestSchemaVersion:
         scheduler.ALERTS_FILE.write_text(json.dumps({"schema_version": 999, "alerts": []}))
         _load_collection_unlocked(scheduler.ALERTS_FILE, "alerts")
         assert "schema_version 999" in caplog.text
+
+
+# ── TestRegisteredCronIds ─────────────────────────────────────────────────────
+
+
+class TestRegisteredCronIds:
+    """Tests for the per-session cron ID tracker (storage.register_new_cron_ids).
+
+    Race condition coverage: register_new_cron_ids is the atomic
+    check-and-update used by `aya hook crons` to dedupe registrations
+    across concurrent PostToolUse hook invocations. Two callers racing
+    on the same candidate ID must agree that exactly one of them sees
+    it as new.
+    """
+
+    def test_first_call_returns_all_candidates(self):
+        from aya.scheduler import (
+            load_registered_cron_ids,
+            register_new_cron_ids,
+        )
+
+        new = register_new_cron_ids({"cron-a", "cron-b"})
+        assert new == {"cron-a", "cron-b"}
+        assert load_registered_cron_ids() == {"cron-a", "cron-b"}
+
+    def test_second_call_returns_only_unseen_subset(self):
+        from aya.scheduler import register_new_cron_ids
+
+        register_new_cron_ids({"cron-a", "cron-b"})
+        new = register_new_cron_ids({"cron-a", "cron-c"})
+        # cron-a was already registered; cron-c is new
+        assert new == {"cron-c"}
+
+    def test_call_with_only_known_ids_returns_empty(self):
+        from aya.scheduler import register_new_cron_ids
+
+        register_new_cron_ids({"cron-a", "cron-b"})
+        new = register_new_cron_ids({"cron-a", "cron-b"})
+        assert new == set()
+
+    def test_empty_input_is_noop(self):
+        from aya.scheduler import load_registered_cron_ids, register_new_cron_ids
+
+        register_new_cron_ids({"cron-a"})
+        new = register_new_cron_ids(set())
+        assert new == set()
+        # Existing tracker state preserved
+        assert load_registered_cron_ids() == {"cron-a"}
+
+    def test_persists_merged_set_across_processes(self, tmp_path):
+        """The tracker file on disk should contain the union of all
+        registered IDs after multiple register calls."""
+        import json as json_
+
+        from aya import scheduler
+        from aya.scheduler import register_new_cron_ids
+
+        register_new_cron_ids({"cron-a"})
+        register_new_cron_ids({"cron-b"})
+        register_new_cron_ids({"cron-c"})
+
+        data = json_.loads(scheduler.REGISTERED_CRONS_FILE.read_text())
+        assert set(data["ids"]) == {"cron-a", "cron-b", "cron-c"}
+
+    def test_reset_clears_tracker(self):
+        from aya.scheduler import (
+            load_registered_cron_ids,
+            register_new_cron_ids,
+            reset_registered_cron_ids,
+        )
+
+        register_new_cron_ids({"cron-a", "cron-b"})
+        reset_registered_cron_ids()
+        assert load_registered_cron_ids() == set()
+
+        # After reset, all candidates are new again
+        new = register_new_cron_ids({"cron-a", "cron-b"})
+        assert new == {"cron-a", "cron-b"}
+
+    def test_reset_when_tracker_does_not_exist(self):
+        """reset_registered_cron_ids should be a no-op when the file is missing."""
+        from aya.scheduler import reset_registered_cron_ids
+
+        # Should not raise even if the file doesn't exist
+        reset_registered_cron_ids()
+        reset_registered_cron_ids()  # idempotent
+
+    def test_load_returns_empty_for_corrupt_file(self, monkeypatch):
+        """Defensive read: a corrupt or malformed tracker should return
+        an empty set rather than crash. This matters because the file
+        is updated under load by parallel hooks; a partial write that
+        somehow slipped past atomic_write would otherwise wedge the
+        scheduler."""
+        from aya import scheduler
+        from aya.scheduler import load_registered_cron_ids
+
+        scheduler.REGISTERED_CRONS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        scheduler.REGISTERED_CRONS_FILE.write_text("not json at all {{{")
+        assert load_registered_cron_ids() == set()
+
+        scheduler.REGISTERED_CRONS_FILE.write_text('{"ids": "not a list"}')
+        assert load_registered_cron_ids() == set()


### PR DESCRIPTION
## Summary

Three fixes from a second-pass code review of tonight's relay-skill follow-up PRs (#195–#198).

## CRITICAL — race in \`save_registered_cron_ids\`

PR #198 added a per-session cron tracker (\`~/.aya/session_registered_crons.json\`) but read and wrote it without holding \`_file_lock()\`. With the new PostToolUse hook firing on every tool call, Claude Code's parallel tool dispatching could race two \`aya hook crons\` subprocesses on the same \`load → set-merge → save\` sequence and double-emit a \`CronCreate\` registration.

**Fix:** introduce \`register_new_cron_ids(candidate_ids)\` — an atomic check-and-update primitive that runs the entire load → diff → save cycle under a single \`_file_lock()\` and returns only the IDs that were *not* previously in the tracker. \`hook_crons\` now uses this instead of the previous unlocked load-save pattern. Two concurrent callers racing on the same cron will agree that exactly one of them sees it as new.

Added \`_load_registered_cron_ids_unlocked\` / \`_save_registered_cron_ids_unlocked\` helpers for callers that hold the lock externally, matching the existing \`_load_items_unlocked\` pattern. Public load/save functions now lock implicitly so they're safe in isolation.

## HIGH — PostToolUse \`aya hook crons\` was synchronous

The PR #198 install.py entry omitted \`"async": True\`, so every tool call paid a Python interpreter cold-start blocking the next tool. Sibling entries (\`aya log auto\`, \`aya hook watch\`) are already async; the crons entry now matches.

**Fix:** add \`"async": True\` + a \`TestCanonicalHookEntries\` lock-in test asserting the entry has \`async=True\` so a future regression triggers a clear failure.

## HIGH — \`_add_cron_entry\` filter too aggressive

The crontab line filter used \`"aya schedule tick" in line OR CRON_COMMENT in line\`. The substring half would falsely match user comments like \`# reminder: investigate aya schedule tick latency\` and silently strip them when rewriting the crontab.

**Fix:** extract \`_is_aya_cron_line()\` that requires the canonical \`CRON_COMMENT\` marker only. Real aya-emitted lines always include the marker, so this is back-compat for any user who installed via aya in the last several months. \`TestHasAyaCron\` updated with explicit positive (canonical line) and negative (user comment mentioning the command) cases plus a back-compat note about pre-marker legacy lines.

## Test plan

- [x] 9 new tests:
  - 8 \`TestRegisteredCronIds\` covering the atomic helper (first call, subset, empty subset, empty input, persistence across calls, reset, missing-file reset, corrupt-file load)
  - 1 \`TestCanonicalHookEntries\` lock-in for the async hook
- [x] 2 new \`TestHasAyaCron\` tests for the false-positive case
- [x] Updated \`test_already_present\` fixture to use a canonical marker line (the old fixture relied on substring matching that no longer holds)
- [x] \`test_scheduler.py\` autouse fixture extended to also patch \`REGISTERED_CRONS_FILE\` and \`LOCK_FILE\` so the tracker tests don't leak writes to \`~/.aya\`
- [x] Full suite: **645 pass** (was 636), lint + format + mypy clean

## Findings deferred

The code review surfaced 6 medium/low items beyond these three. They're all reasonable concerns but lower priority — moving to the inbox follow-ups list:

| | Severity | What |
|---|---|---|
| Cross-session tracker collision | Medium | Single tracker file path; two concurrent Claude sessions share it. Mostly benign (Claude likely idempotent on CronCreate id) but worth keying on session id |
| \`1s\` tick interval guardrail | Medium | \`parse_tick_interval\` accepts 1s with no minimum; consider \`MIN_TICK_SECONDS\` |
| \`2>/dev/null \|\| true\` hides errors | Medium | PostToolUse hook swallows stderr; tracker desync would be invisible |
| \`_extract_body\` JSON fallback | Low | \`json.dumps(..., default=str)\` stringifies non-serializable values; consider passing through original dict in JSON output mode |
| \`aya drop\` no relay timeout | Low | \`fetch_pending\` loop has no time bound; pre-existing pattern from \`aya inbox\` |
| \`aya send\` re-sign visibility | Low | Re-sign only logs at info; consider a one-line console message in non-JSON output |

🤖 Generated with [Claude Code](https://claude.com/claude-code)