### PR TITLE
fix(cli,install): enforce 5s minimum tick interval; surface aya send re-sign

### DIFF
--- a/src/aya/cli.py
+++ b/src/aya/cli.py
@@ -623,6 +623,11 @@ def send(
         if packet.from_did == local.did:
             packet = packet.sign(local)
             logger.info("Re-signed packet %s with local instance key", packet.id)
+            if format_ != OutputFormat.JSON:
+                err.print(
+                    "[dim]Re-signed packet with local instance key "
+                    "(signature was missing or invalid).[/dim]"
+                )
         else:
             _emit_error(
                 ErrorCode.INVALID_ARGUMENT,

--- a/src/aya/install.py
+++ b/src/aya/install.py
@@ -15,6 +15,14 @@ logger = logging.getLogger(__name__)
 # ── Constants ────────────────────────────────────────────────────────────────
 
 DEFAULT_TICK_INTERVAL = "5m"  # Conservative default; configurable via --tick-interval
+
+# Minimum supported tick interval in seconds. Sub-5s ticks generate
+# 12+ crontab lines per minute (60 / N), each spawning a Python
+# interpreter; cron wasn't designed for this workload. Users who need
+# genuine sub-5s polling should write a proper long-running daemon
+# instead of abusing the scheduler tick.
+MIN_TICK_SECONDS = 5
+
 CRON_COMMENT = "# aya-scheduler-tick"
 
 CLAUDE_SETTINGS_PATH = Path.home() / ".claude" / "settings.json"
@@ -163,12 +171,16 @@ def _resolve_aya_path() -> str | None:
 def parse_tick_interval(text: str) -> int:
     """Parse a tick-interval string into total seconds.
 
-    Accepts forms like ``"30s"``, ``"1m"``, ``"5m"``, ``"1h"`` (single
-    unit only). Returns the duration in seconds.
+    Accepts forms like ``"5s"``, ``"30s"``, ``"1m"``, ``"5m"``, ``"1h"``
+    (single unit only). Returns the duration in seconds.
 
-    Raises ValueError on bad input or non-positive values, or on values
-    that exceed the supported range (1s … 60m). The upper bound exists
-    because cron's ``*/N`` syntax doesn't generalize cleanly past 60.
+    Raises ValueError on bad input, non-positive values, values below
+    ``MIN_TICK_SECONDS`` (currently 5s), or values above 60m. The lower
+    bound exists because sub-5s intervals generate 12+ crontab entries
+    per minute (each spawning a Python interpreter) — if you genuinely
+    need faster polling, run a long-running daemon instead of abusing
+    the scheduler tick. The upper bound exists because cron's ``*/N``
+    syntax doesn't generalize cleanly past 60.
     """
     text = text.strip().lower()
     if not text:
@@ -197,8 +209,14 @@ def parse_tick_interval(text: str) -> int:
         raise ValueError(f"Tick interval must be positive: {text!r}")
 
     seconds = n * unit_secs
-    if seconds < 1 or seconds > 3600:
-        raise ValueError(f"Tick interval must be between 1s and 60m, got {text!r} ({seconds}s)")
+    if seconds < MIN_TICK_SECONDS:
+        raise ValueError(
+            f"Tick interval must be at least {MIN_TICK_SECONDS}s, got {text!r} "
+            f"({seconds}s). Sub-{MIN_TICK_SECONDS}s intervals spawn too many "
+            "cron subprocesses per minute; use a long-running daemon instead."
+        )
+    if seconds > 3600:
+        raise ValueError(f"Tick interval must be at most 60m, got {text!r} ({seconds}s)")
     return seconds
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3696,3 +3696,41 @@ class TestSendSignatureValidation:
         assert result.exit_code == 0, result.output
         # Signature unchanged — pass-through, not re-signed
         assert captured["packet"].signature == original_sig
+
+    def test_resign_surfaces_console_notice_in_text_mode(
+        self, profile_with_trusted: Path, tmp_path: Path
+    ) -> None:
+        """When aya send re-signs in interactive/text mode, the user
+        should see a visible notice. Silent mutation is surprising."""
+        p = Profile.load(profile_with_trusted)
+        local = p.instances["default"]
+        home_key = p.trusted_keys["home"]
+
+        pkt = Packet(
+            **{"from": local.did, "to": home_key.did},
+            intent="silent resign",
+            content="hello",
+        )
+        assert pkt.signature is None
+        packet_file = tmp_path / "packet.json"
+        packet_file.write_text(pkt.to_json())
+
+        async def fake_publish(packet, *args, **kwargs):
+            return "e" * 64
+
+        with patch("aya.cli.RelayClient") as mock_cls:
+            mock_cls.return_value.publish = fake_publish
+            result = runner.invoke(
+                app,
+                [
+                    "send",
+                    str(packet_file),
+                    "--profile",
+                    str(profile_with_trusted),
+                    "--format",
+                    "text",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert "Re-signed packet" in result.output

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -183,7 +183,7 @@ class TestCanonicalHookEntries:
 class TestParseTickInterval:
     def test_seconds(self) -> None:
         assert parse_tick_interval("30s") == 30
-        assert parse_tick_interval("1s") == 1
+        assert parse_tick_interval("5s") == 5  # minimum
         assert parse_tick_interval("59s") == 59
 
     def test_minutes(self) -> None:
@@ -223,8 +223,17 @@ class TestParseTickInterval:
             parse_tick_interval("-5m")
 
     def test_rejects_above_60m(self) -> None:
-        with pytest.raises(ValueError, match="between 1s and 60m"):
+        with pytest.raises(ValueError, match="at most 60m"):
             parse_tick_interval("2h")
+
+    def test_rejects_below_minimum_seconds(self) -> None:
+        """Sub-5s intervals would generate 12+ crontab lines per minute
+        and spawn a Python interpreter for each; the scheduler tick
+        wasn't designed for that workload. Users who need finer-grained
+        polling should run a long-running daemon instead."""
+        for too_small in ("1s", "2s", "4s"):
+            with pytest.raises(ValueError, match="at least 5s"):
+                parse_tick_interval(too_small)
 
 
 # ── Hook install/uninstall (real files) ──────────────────────────────────────


### PR DESCRIPTION
## Summary

Two small UX fixes deferred from the PR #195–#198 code review. Low risk, each lock-in tested.

### MIN_TICK_SECONDS guardrail

\`parse_tick_interval()\` previously accepted any value from 1s–60m. Sub-5s intervals generate 12+ crontab lines per minute (60/N), each spawning a Python interpreter for the scheduler tick — cron wasn't designed for this workload.

Add a \`MIN_TICK_SECONDS = 5\` floor with an error message that points at the "use a long-running daemon instead" escape hatch.

\`\`\`
$ aya schedule install --tick-interval 1s
Error: invalid tick_interval: Tick interval must be at least 5s, got '1s' (1s).
Sub-5s intervals spawn too many cron subprocesses per minute; use a
long-running daemon instead.
\`\`\`

### \`aya send\` re-sign console notice

The auto-resign path in PR #196 silently mutated the packet and only logged at info level. Interactive users running \`aya send\` from a terminal had no feedback that the packet had been signed on their behalf.

Add a single stderr line in text output mode:

\`\`\`
$ aya send my-packet.json
Re-signed packet with local instance key (signature was missing or invalid).
✓ Sent my intent
  Packet: abc12345  Event: def67890  Relay: wss://relay.damus.io
\`\`\`

JSON output mode is unchanged.

## Test plan

- [x] \`TestParseTickInterval.test_rejects_below_minimum_seconds\` covers 1s/2s/4s
- [x] Existing \`test_seconds\` updated: \`5s\` is the minimum valid case
- [x] \`TestSendSignatureValidation.test_resign_surfaces_console_notice_in_text_mode\` locks the visible output in text mode
- [x] Full suite: 647 pass, lint + format + mypy clean

## Remaining deferred from code review

| | Status |
|---|---|
| Cross-session tracker collision | still deferred (benign in practice, needs session-id keying) |
| \`2>/dev/null \|\| true\` swallows stderr | still deferred (needs logger-to-file wiring) |
| \`_extract_body\` JSON fallback | still deferred |
| \`aya drop\` no relay timeout | still deferred (pre-existing pattern from \`inbox\`) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)