### PR TITLE
fix(cli): aya read passes structured body through in JSON mode

### DIFF
--- a/src/aya/cli.py
+++ b/src/aya/cli.py
@@ -2605,10 +2605,21 @@ def read(
     from aya.packet import Packet
 
     packet = Packet.from_json(matches[0].read_text())
-    body = _extract_body(packet.content, packet.content_type)
 
     if format_ == OutputFormat.JSON:
-        result: dict[str, object] = {"id": packet.id, "body": body}
+        # In JSON output mode, non-seed dict content (e.g. application/json
+        # packets) is passed through as a structured value rather than
+        # stringified. Callers that ``jq`` or ``python -c 'json.load'`` over
+        # the output get a real object, not a string containing pretty-printed
+        # JSON. Seed-shape dicts still go through _extract_body so the
+        # ``body`` field stays a readable string (opener + context + qs).
+        body_value: object
+        if isinstance(packet.content, dict) and packet.content_type != ContentType.SEED:
+            body_value = packet.content
+        else:
+            body_value = _extract_body(packet.content, packet.content_type)
+
+        result: dict[str, object] = {"id": packet.id, "body": body_value}
         if meta:
             result["from"] = packet.from_did
             result["sent_at"] = packet.sent_at
@@ -2617,6 +2628,8 @@ def read(
         _output_json(result)
         raise typer.Exit(0)
 
+    # Text mode — always render as a string via _extract_body.
+    body = _extract_body(packet.content, packet.content_type)
     if meta:
         console.print(f"[bold]{packet.intent}[/bold]  ·  {packet.id[:12]}")
         console.print(f"[dim]from {packet.from_did[:30]}…  ·  {packet.sent_at[:16]}[/dim]")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3259,14 +3259,13 @@ class TestRead:
     def seed_packet(self) -> Packet:
         local = Identity.generate("default")
         home = Identity.generate("home")
-        return Packet(
-            **{"from": home.did, "to": local.did},
+        return Packet.as_seed(
+            from_did=home.did,
+            to_did=local.did,
             intent="seed test",
-            content={
-                "opener": "What's the plan for tomorrow?",
-                "context_summary": "Wrapping up the relay project.",
-                "open_questions": ["who reviews?", "merge target?"],
-            },
+            opener="What's the plan for tomorrow?",
+            context_summary="Wrapping up the relay project.",
+            open_questions=["who reviews?", "merge target?"],
         )
 
     @pytest.fixture
@@ -3335,6 +3334,58 @@ class TestRead:
     def test_prefix_too_short_errors(self, packets_dir: Path) -> None:
         result = runner.invoke(app, ["read", "01XX", "--format", "text"])
         assert result.exit_code != 0
+
+    def test_json_format_preserves_structured_body_for_json_content(
+        self, packets_dir: Path
+    ) -> None:
+        """Non-seed dict content must pass through as a structured object
+        in JSON output mode, not be stringified. Callers that pipe
+        ``aya read --format json | jq`` should get a real object back."""
+        from aya.packet import ContentType
+
+        local = Identity.generate("default")
+        home = Identity.generate("home")
+        pkt = Packet(
+            **{"from": home.did, "to": local.did},
+            intent="structured payload",
+            content_type=ContentType.JSON,
+            content={
+                "event": "deployed",
+                "version": "1.2.3",
+                "checks": ["lint", "test"],
+            },
+        )
+        (packets_dir / f"{pkt.id}.json").write_text(pkt.to_json())
+
+        result = runner.invoke(app, ["read", pkt.id, "--format", "json"])
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        # body is a dict, not a string containing pretty-printed JSON
+        assert isinstance(data["body"], dict)
+        assert data["body"]["event"] == "deployed"
+        assert data["body"]["version"] == "1.2.3"
+        assert data["body"]["checks"] == ["lint", "test"]
+
+    def test_text_format_still_stringifies_json_content(self, packets_dir: Path) -> None:
+        """Text mode output hasn't regressed: non-seed dicts still render as
+        pretty-printed JSON for human reading."""
+        from aya.packet import ContentType
+
+        local = Identity.generate("default")
+        home = Identity.generate("home")
+        pkt = Packet(
+            **{"from": home.did, "to": local.did},
+            intent="structured payload",
+            content_type=ContentType.JSON,
+            content={"event": "deployed", "version": "1.2.3"},
+        )
+        (packets_dir / f"{pkt.id}.json").write_text(pkt.to_json())
+
+        result = runner.invoke(app, ["read", pkt.id, "--format", "text"])
+        assert result.exit_code == 0, result.output
+        # Text mode prints the pretty-printed JSON body
+        assert '"event": "deployed"' in result.output
+        assert '"version": "1.2.3"' in result.output
 
 
 # ── TestDrop ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Last medium-priority finding from the PR #195–#198 code review.

**Before:** \`_extract_body()\` always returned a string. For non-seed dict content (e.g. \`application/json\` packets), it serialized via \`json.dumps(default=str)\`, so \`aya read --format json\` produced:

\`\`\`json
{
  "id": "...",
  "body": "{\n  \"event\": \"deployed\",\n  \"version\": \"1.2.3\"\n}"
}
\`\`\`

The \`body\` field was a string containing pretty-printed JSON rather than a real object. Callers that \`jq\` or \`json.load\` the output had to parse twice, and \`default=str\` silently stringified anything non-serializable (datetime, UUID, etc).

**After:** in JSON output mode, non-seed dict content passes through as-is:

\`\`\`json
{
  "id": "...",
  "body": {
    "event": "deployed",
    "version": "1.2.3"
  }
}
\`\`\`

Seed packets still go through \`_extract_body\` so the \`body\` stays a readable string (opener + context + questions). Text mode is unchanged — dicts still render as pretty-printed JSON for human reading.

## Drive-by fix

The \`TestRead\` \`seed_packet\` fixture was building a seed-shaped dict with the default \`content_type=MARKDOWN\`, which made \`_extract_body\`'s seed path unreachable. Existing text-mode tests passed by accident because "What's the plan" appears in the fallback \`json.dumps\` output regardless. The fixture now uses \`Packet.as_seed()\` which correctly sets \`content_type=SEED\`, so the tests actually exercise the seed path.

## Test plan

- [x] \`test_json_format_preserves_structured_body_for_json_content\` — asserts \`data["body"]\` is a dict with the right fields
- [x] \`test_text_format_still_stringifies_json_content\` — locks in unchanged text-mode behavior
- [x] Existing 8 \`TestRead\` tests still pass (now correctly exercising the seed path)
- [x] Full suite: 649 pass, lint + format + mypy clean

## Remaining deferred from code review

| | Status |
|---|---|
| Cross-session tracker collision | still deferred (benign; needs session-id keying) |
| \`2>/dev/null \|\| true\` swallows stderr | still deferred (needs logger-to-file wiring) |
| \`aya drop\` no relay timeout | still deferred (pre-existing pattern from \`inbox\`) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)