### PR TITLE
feat(cli): aya relay subcommand for managing default_relays

### DIFF
--- a/src/aya/cli.py
+++ b/src/aya/cli.py
@@ -156,6 +156,15 @@ config_app = typer.Typer(
 )
 app.add_typer(config_app, name="config")
 
+# ── Relay sub-app ─────────────────────────────────────────────────────────────
+
+relay_app = typer.Typer(
+    name="relay",
+    help="Manage default Nostr relays used by send/receive/dispatch.",
+    no_args_is_help=True,
+)
+app.add_typer(relay_app, name="relay")
+
 console = Console()
 err = Console(stderr=True)
 
@@ -2868,6 +2877,168 @@ def config_show() -> None:
     for k, v in sorted(config.items()):
         table.add_row(k, str(v))
     console.print(table)
+
+
+# ── Relay subcommands ────────────────────────────────────────────────────────
+
+
+def _load_profile_for_relay(profile_path: Path) -> Profile:
+    """Load a profile, emitting a structured error if it doesn't exist."""
+    if not profile_path.exists():
+        _emit_error(
+            ErrorCode.PROFILE_NOT_FOUND,
+            f"Profile not found at {profile_path}. Run `aya init` first.",
+            context={"profile_path": str(profile_path)},
+        )
+    return Profile.load(profile_path)
+
+
+def _validate_relay_url(url: str) -> None:
+    """Reject anything that isn't a ws:// or wss:// URL."""
+    if not url.startswith(("wss://", "ws://")):
+        _emit_error(
+            ErrorCode.INVALID_ARGUMENT,
+            f"Relay URL must start with wss:// or ws:// (got {url!r}).",
+            context={"url": url},
+            exit_code=2,
+        )
+
+
+@relay_app.command("list")
+def relay_list(
+    profile: Path = typer.Option(DEFAULT_PROFILE, help="Path to profile.json"),
+    format_: OutputFormat = typer.Option(
+        OutputFormat.AUTO, "--format", "-f", help="Output format: auto (default), text, or json"
+    ),
+) -> None:
+    """Show the current default relays (in polling order)."""
+    format_ = resolve_format(format_)
+    p = _load_profile_for_relay(profile)
+    relays = list(p.default_relays)
+
+    if format_ == OutputFormat.JSON:
+        _output_json({"relays": relays, "count": len(relays)})
+        return
+
+    if not relays:
+        console.print("[dim]No relays configured.[/dim]")
+        return
+
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("#", justify="right", style="dim")
+    table.add_column("Relay URL")
+    for i, url in enumerate(relays, start=1):
+        table.add_row(str(i), url)
+    console.print(table)
+
+
+@relay_app.command("add")
+def relay_add(
+    url: str = typer.Argument(..., help="Relay URL (wss://… or ws://…)"),
+    first: bool = typer.Option(
+        False, "--first", help="Prepend instead of append (makes this the primary relay)"
+    ),
+    profile: Path = typer.Option(DEFAULT_PROFILE, help="Path to profile.json"),
+    format_: OutputFormat = typer.Option(
+        OutputFormat.AUTO, "--format", "-f", help="Output format: auto (default), text, or json"
+    ),
+) -> None:
+    """Add a relay to default_relays. Duplicates are a no-op."""
+    format_ = resolve_format(format_)
+    _validate_relay_url(url)
+    p = _load_profile_for_relay(profile)
+
+    relays = list(p.default_relays)
+    if url in relays:
+        if format_ == OutputFormat.JSON:
+            _output_json({"ok": True, "already_present": True, "relays": relays})
+            return
+        console.print(f"[dim]{url} is already in default_relays — no change.[/dim]")
+        return
+
+    if first:
+        relays.insert(0, url)
+    else:
+        relays.append(url)
+    p.default_relays = relays
+    p.save(profile)
+
+    if format_ == OutputFormat.JSON:
+        _output_json(
+            {
+                "ok": True,
+                "added": url,
+                "position": "first" if first else "last",
+                "relays": relays,
+            }
+        )
+        return
+    role = "primary" if first else "fallback"
+    console.print(f"[green]✓[/green] Added [cyan]{url}[/cyan] ({role})")
+    console.print(f"[dim]Saved to {profile}[/dim]")
+
+
+@relay_app.command("remove")
+def relay_remove(
+    target: str = typer.Argument(..., help="Relay URL or 1-based list index to remove"),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help="Allow removing the last remaining relay. Note: Profile.load() auto-refills an "
+        "empty list with the bootstrap defaults (damus + nos.lol) on next load, so this "
+        "effectively resets to defaults.",
+    ),
+    profile: Path = typer.Option(DEFAULT_PROFILE, help="Path to profile.json"),
+    format_: OutputFormat = typer.Option(
+        OutputFormat.AUTO, "--format", "-f", help="Output format: auto (default), text, or json"
+    ),
+) -> None:
+    """Remove a relay by URL or 1-based index."""
+    format_ = resolve_format(format_)
+    p = _load_profile_for_relay(profile)
+    relays = list(p.default_relays)
+
+    # Resolve target: integer index or URL match
+    removed: str | None = None
+    if target.isdigit():
+        idx = int(target) - 1
+        if idx < 0 or idx >= len(relays):
+            _emit_error(
+                ErrorCode.INVALID_ARGUMENT,
+                f"Index {target} out of range (list has {len(relays)} relays).",
+                context={"index": target, "count": len(relays)},
+                exit_code=2,
+            )
+        removed = relays.pop(idx)
+    elif target in relays:
+        relays.remove(target)
+        removed = target
+    else:
+        _emit_error(
+            ErrorCode.INVALID_ARGUMENT,
+            f"Relay {target!r} not found in default_relays.",
+            context={"target": target, "relays": list(p.default_relays)},
+            exit_code=2,
+        )
+
+    if not relays and not force:
+        _emit_error(
+            ErrorCode.INVALID_ARGUMENT,
+            "Refusing to remove the last relay. Use --force to empty the list.",
+            context={"removed": removed},
+            exit_code=2,
+        )
+
+    p.default_relays = relays
+    p.save(profile)
+
+    if format_ == OutputFormat.JSON:
+        _output_json({"ok": True, "removed": removed, "relays": relays})
+        return
+    console.print(f"[green]✓[/green] Removed [cyan]{removed}[/cyan]")
+    if not relays:
+        console.print("[yellow]⚠ default_relays is now empty.[/yellow]")
+    console.print(f"[dim]Saved to {profile}[/dim]")
 
 
 # ── Clipboard helper ─────────────────────────────────────────────────────────

--- a/src/aya/cli.py
+++ b/src/aya/cli.py
@@ -11,6 +11,7 @@ import re
 import shutil
 import subprocess
 import sys
+import urllib.parse
 from contextlib import nullcontext, suppress
 from datetime import UTC, datetime, timedelta
 from enum import StrEnum
@@ -2883,22 +2884,17 @@ def config_show() -> None:
 
 
 def _load_profile_for_relay(profile_path: Path) -> Profile:
-    """Load a profile, emitting a structured error if it doesn't exist."""
-    if not profile_path.exists():
-        _emit_error(
-            ErrorCode.PROFILE_NOT_FOUND,
-            f"Profile not found at {profile_path}. Run `aya init` first.",
-            context={"profile_path": str(profile_path)},
-        )
-    return Profile.load(profile_path)
+    """Load a profile for relay commands using the standard profile loader."""
+    return _load_profile(profile_path)
 
 
 def _validate_relay_url(url: str) -> None:
-    """Reject anything that isn't a ws:// or wss:// URL."""
-    if not url.startswith(("wss://", "ws://")):
+    """Reject anything that isn't a valid ws:// or wss:// URL with a non-empty host."""
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme not in {"ws", "wss"} or not parsed.hostname or url != url.strip():
         _emit_error(
             ErrorCode.INVALID_ARGUMENT,
-            f"Relay URL must start with wss:// or ws:// (got {url!r}).",
+            f"Relay URL must be a valid wss:// or ws:// address with a hostname (got {url!r}).",
             context={"url": url},
             exit_code=2,
         )
@@ -2985,8 +2981,8 @@ def relay_remove(
         False,
         "--force",
         help="Allow removing the last remaining relay. Note: Profile.load() auto-refills an "
-        "empty list with the bootstrap defaults (damus + nos.lol) on next load, so this "
-        "effectively resets to defaults.",
+        "empty list with the bootstrap defaults on next load, so this effectively resets "
+        "to defaults.",
     ),
     profile: Path = typer.Option(DEFAULT_PROFILE, help="Path to profile.json"),
     format_: OutputFormat = typer.Option(
@@ -3036,8 +3032,11 @@ def relay_remove(
         _output_json({"ok": True, "removed": removed, "relays": relays})
         return
     console.print(f"[green]✓[/green] Removed [cyan]{removed}[/cyan]")
-    if not relays:
-        console.print("[yellow]⚠ default_relays is now empty.[/yellow]")
+    if not relays and force:
+        console.print(
+            "[yellow]⚠ default_relays was saved empty, but bootstrap defaults will be "
+            "restored on the next profile load.[/yellow]"
+        )
     console.print(f"[dim]Saved to {profile}[/dim]")
 
 

--- a/src/aya/cli.py
+++ b/src/aya/cli.py
@@ -2889,9 +2889,15 @@ def _load_profile_for_relay(profile_path: Path) -> Profile:
 
 
 def _validate_relay_url(url: str) -> None:
-    """Reject anything that isn't a valid ws:// or wss:// URL with a non-empty host."""
+    """Reject anything that isn't a valid ws:// or wss:// URL with a non-empty host.
+
+    Rejects whitespace anywhere in the URL, not just leading/trailing — urlparse
+    happily accepts 'wss://relay .example' with a space in the netloc, which
+    would later fail at websockets.connect() rather than at the CLI boundary.
+    """
     parsed = urllib.parse.urlparse(url)
-    if parsed.scheme not in {"ws", "wss"} or not parsed.hostname or url != url.strip():
+    has_whitespace = any(c.isspace() for c in url)
+    if parsed.scheme not in {"ws", "wss"} or not parsed.hostname or has_whitespace:
         _emit_error(
             ErrorCode.INVALID_ARGUMENT,
             f"Relay URL must be a valid wss:// or ws:// address with a hostname (got {url!r}).",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3867,3 +3867,270 @@ class TestSendSignatureValidation:
 
         assert result.exit_code == 0, result.output
         assert "Re-signed packet" in result.output
+
+
+# ── TestRelaySubcommand ───────────────────────────────────────────────────────
+
+
+class TestRelayList:
+    def test_list_text_shows_relays_in_order(self, profile_with_instance: Path) -> None:
+        p = Profile.load(profile_with_instance)
+        p.default_relays = ["wss://relay.damus.io", "wss://nos.lol"]
+        p.save(profile_with_instance)
+
+        result = runner.invoke(
+            app,
+            ["relay", "list", "--profile", str(profile_with_instance), "--format", "text"],
+        )
+        assert result.exit_code == 0, result.output
+        assert "wss://relay.damus.io" in result.output
+        assert "wss://nos.lol" in result.output
+        # Order check: damus appears before nos.lol
+        assert result.output.index("wss://relay.damus.io") < result.output.index("wss://nos.lol")
+
+    def test_list_json_shape(self, profile_with_instance: Path) -> None:
+        p = Profile.load(profile_with_instance)
+        p.default_relays = ["wss://a.example", "wss://b.example"]
+        p.save(profile_with_instance)
+
+        result = runner.invoke(
+            app,
+            ["relay", "list", "--profile", str(profile_with_instance), "--format", "json"],
+        )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload == {"relays": ["wss://a.example", "wss://b.example"], "count": 2}
+
+    def test_list_missing_profile_emits_structured_error(self, tmp_path: Path) -> None:
+        missing = tmp_path / "does-not-exist.json"
+        result = runner.invoke(
+            app,
+            ["relay", "list", "--profile", str(missing), "--format", "json"],
+        )
+        assert result.exit_code == 1
+        # Structured error goes to stderr, but CliRunner merges by default.
+        # The error code should be recognizable either way.
+        combined = result.output + (result.stderr if hasattr(result, "stderr") else "")
+        assert "PROFILE_NOT_FOUND" in combined or "not found" in combined.lower()
+
+
+class TestRelayAdd:
+    def test_add_appends_by_default(self, profile_with_instance: Path) -> None:
+        p = Profile.load(profile_with_instance)
+        p.default_relays = ["wss://first.example"]
+        p.save(profile_with_instance)
+
+        result = runner.invoke(
+            app,
+            [
+                "relay",
+                "add",
+                "wss://second.example",
+                "--profile",
+                str(profile_with_instance),
+                "--format",
+                "text",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+
+        reloaded = Profile.load(profile_with_instance)
+        assert reloaded.default_relays == ["wss://first.example", "wss://second.example"]
+
+    def test_add_first_prepends(self, profile_with_instance: Path) -> None:
+        p = Profile.load(profile_with_instance)
+        p.default_relays = ["wss://existing.example"]
+        p.save(profile_with_instance)
+
+        result = runner.invoke(
+            app,
+            [
+                "relay",
+                "add",
+                "wss://new.example",
+                "--first",
+                "--profile",
+                str(profile_with_instance),
+                "--format",
+                "text",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+
+        reloaded = Profile.load(profile_with_instance)
+        assert reloaded.default_relays == ["wss://new.example", "wss://existing.example"]
+
+    def test_add_duplicate_is_noop(self, profile_with_instance: Path) -> None:
+        p = Profile.load(profile_with_instance)
+        p.default_relays = ["wss://dup.example"]
+        p.save(profile_with_instance)
+
+        result = runner.invoke(
+            app,
+            [
+                "relay",
+                "add",
+                "wss://dup.example",
+                "--profile",
+                str(profile_with_instance),
+                "--format",
+                "json",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["already_present"] is True
+        assert payload["relays"] == ["wss://dup.example"]
+
+        # Profile unchanged
+        reloaded = Profile.load(profile_with_instance)
+        assert reloaded.default_relays == ["wss://dup.example"]
+
+    def test_add_rejects_non_websocket_scheme(self, profile_with_instance: Path) -> None:
+        result = runner.invoke(
+            app,
+            [
+                "relay",
+                "add",
+                "https://not-a-relay.example",
+                "--profile",
+                str(profile_with_instance),
+                "--format",
+                "json",
+            ],
+        )
+        assert result.exit_code == 2, result.output
+
+
+class TestRelayRemove:
+    def test_remove_by_url(self, profile_with_instance: Path) -> None:
+        p = Profile.load(profile_with_instance)
+        p.default_relays = ["wss://a.example", "wss://b.example", "wss://c.example"]
+        p.save(profile_with_instance)
+
+        result = runner.invoke(
+            app,
+            [
+                "relay",
+                "remove",
+                "wss://b.example",
+                "--profile",
+                str(profile_with_instance),
+                "--format",
+                "text",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+
+        reloaded = Profile.load(profile_with_instance)
+        assert reloaded.default_relays == ["wss://a.example", "wss://c.example"]
+
+    def test_remove_by_index(self, profile_with_instance: Path) -> None:
+        p = Profile.load(profile_with_instance)
+        p.default_relays = ["wss://a.example", "wss://b.example", "wss://c.example"]
+        p.save(profile_with_instance)
+
+        result = runner.invoke(
+            app,
+            [
+                "relay",
+                "remove",
+                "2",
+                "--profile",
+                str(profile_with_instance),
+                "--format",
+                "json",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["removed"] == "wss://b.example"
+
+        reloaded = Profile.load(profile_with_instance)
+        assert reloaded.default_relays == ["wss://a.example", "wss://c.example"]
+
+    def test_remove_unknown_url_errors(self, profile_with_instance: Path) -> None:
+        p = Profile.load(profile_with_instance)
+        p.default_relays = ["wss://a.example"]
+        p.save(profile_with_instance)
+
+        result = runner.invoke(
+            app,
+            [
+                "relay",
+                "remove",
+                "wss://nope.example",
+                "--profile",
+                str(profile_with_instance),
+                "--format",
+                "json",
+            ],
+        )
+        assert result.exit_code == 2, result.output
+
+        # Profile unchanged
+        reloaded = Profile.load(profile_with_instance)
+        assert reloaded.default_relays == ["wss://a.example"]
+
+    def test_remove_index_out_of_range_errors(self, profile_with_instance: Path) -> None:
+        p = Profile.load(profile_with_instance)
+        p.default_relays = ["wss://only.example"]
+        p.save(profile_with_instance)
+
+        result = runner.invoke(
+            app,
+            [
+                "relay",
+                "remove",
+                "5",
+                "--profile",
+                str(profile_with_instance),
+                "--format",
+                "json",
+            ],
+        )
+        assert result.exit_code == 2, result.output
+
+    def test_remove_last_requires_force(self, profile_with_instance: Path) -> None:
+        p = Profile.load(profile_with_instance)
+        p.default_relays = ["wss://only.example"]
+        p.save(profile_with_instance)
+
+        # Without --force: refuses
+        result = runner.invoke(
+            app,
+            [
+                "relay",
+                "remove",
+                "wss://only.example",
+                "--profile",
+                str(profile_with_instance),
+                "--format",
+                "json",
+            ],
+        )
+        assert result.exit_code == 2, result.output
+        reloaded = Profile.load(profile_with_instance)
+        assert reloaded.default_relays == ["wss://only.example"]
+
+        # With --force: allowed. The CLI response reports an empty list,
+        # but Profile.load() auto-refills from _DEFAULT_RELAYS on next read
+        # (safety net in identity.py), so the disk state effectively resets
+        # to the bootstrap defaults. We assert on the CLI response directly.
+        result = runner.invoke(
+            app,
+            [
+                "relay",
+                "remove",
+                "wss://only.example",
+                "--force",
+                "--profile",
+                str(profile_with_instance),
+                "--format",
+                "json",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["removed"] == "wss://only.example"
+        assert payload["relays"] == []

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4001,6 +4001,40 @@ class TestRelayAdd:
         )
         assert result.exit_code == 2, result.output
 
+    def test_add_rejects_bare_scheme(self, profile_with_instance: Path) -> None:
+        """wss:// with no host must not persist (Copilot review catch on #213)."""
+        result = runner.invoke(
+            app,
+            [
+                "relay",
+                "add",
+                "wss://",
+                "--profile",
+                str(profile_with_instance),
+                "--format",
+                "json",
+            ],
+        )
+        assert result.exit_code == 2, result.output
+        reloaded = Profile.load(profile_with_instance)
+        assert "wss://" not in reloaded.default_relays
+
+    def test_add_rejects_internal_whitespace(self, profile_with_instance: Path) -> None:
+        """urlparse accepts 'wss://relay .example' silently; the CLI must not."""
+        result = runner.invoke(
+            app,
+            [
+                "relay",
+                "add",
+                "wss://relay .example",
+                "--profile",
+                str(profile_with_instance),
+                "--format",
+                "json",
+            ],
+        )
+        assert result.exit_code == 2, result.output
+
 
 class TestRelayRemove:
     def test_remove_by_url(self, profile_with_instance: Path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "aya-ai-assist"
-version = "1.28.0"
+version = "1.29.0"
 source = { editable = "." }
 dependencies = [
     { name = "base58" },


### PR DESCRIPTION
## Summary

- Adds `aya relay list | add | remove` for managing `default_relays` without hand-editing `~/.aya/profile.json`
- Motivated by standing up `wss://relay.monocularjack.com` on Babar today — had to `python3 -c` into the profile, which is exactly the friction this feature removes
- Closes #212

## What changes

Three new commands under a new `relay` sub-app:

| Command | Behavior |
|---|---|
| `aya relay list` | Numbered list, supports `--format json` |
| `aya relay add <url> [--first]` | Append (or prepend with `--first`); rejects non-`ws`/`wss`; duplicate is a no-op |
| `aya relay remove <url\|index>` | By URL or 1-based index; `--force` to empty (with caveat) |

All three accept `--profile` and `--format`, consistent with the rest of the CLI. Structured errors on stderr use `ErrorCode.INVALID_ARGUMENT` (exit 2) and `ErrorCode.PROFILE_NOT_FOUND` (exit 1).

### The `--force` caveat

`Profile.load()` has a safety net (`identity.py:334-336`) that auto-refills an empty `default_relays` with `_DEFAULT_RELAYS` on read. So `aya relay remove <last> --force` effectively resets to the bootstrap defaults on next load rather than leaving a truly empty list. The `--force` help text documents this so nobody is surprised.

## Out of scope (explicitly)

- No change to `_DEFAULT_RELAYS` bootstrap constant — personal relays shouldn't ship as public defaults
- No `aya relay test <url>` reachability check — listed as optional in #212; deferred to a follow-up to keep this PR tight (adds async + websocket handling + potential CI flakiness)
- No migration of `aya init`'s `--relay` flag to this sub-app — separate concern

## Test plan

- [x] `aya relay list` on live profile returns all 3 relays in order (manual)
- [x] 12 new tests in `tests/test_cli.py`, covering:
  - list: text order, JSON shape, missing-profile error
  - add: append, `--first` prepend, duplicate no-op, non-`ws` scheme rejection
  - remove: by URL, by index, unknown URL error, out-of-range index error, last-relay guard with and without `--force`
- [x] Full `tests/test_cli.py` suite (159 tests) still green
- [x] `mypy src/aya/cli.py` clean
- [x] `ruff check` + `ruff format` clean (hooks passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)