### PR TITLE
feat(cli): add cross-references between send, pack, and dispatch help text

### DIFF
--- a/src/aya/cli.py
+++ b/src/aya/cli.py
@@ -524,7 +524,11 @@ def pack(
         OutputFormat.AUTO, "--format", "-f", help="Output format: auto (default), text, or json"
     ),
 ) -> None:
-    """Pack a knowledge packet ready to send."""
+    """Pack a knowledge packet ready to send.
+
+    To pack and send in one step: aya dispatch --to <label> --intent "..."
+    See also: aya send (send a pre-built packet file)
+    """
     if instance is not None and as_ != "default":
         _emit_error(
             ErrorCode.INVALID_ARGUMENT,
@@ -609,7 +613,13 @@ def send(
         OutputFormat.AUTO, "--format", "-f", help="Output format: auto (default), text, or json"
     ),
 ) -> None:
-    """Send a packet to a Nostr relay."""
+    """Send a packet to a Nostr relay.
+
+    This sends a pre-built packet file. To compose and send in one step:
+      aya dispatch --to <label> --intent "..."
+
+    See also: aya pack (create a packet without sending)
+    """
     logger.debug("send: packet_file=%s, as=%s", packet_file, as_)
     if instance is not None and as_ != "default":
         _emit_error(
@@ -734,7 +744,11 @@ def dispatch(
         OutputFormat.AUTO, "--format", "-f", help="Output format: auto (default), text, or json"
     ),
 ) -> None:
-    """Pack and send in one step — the natural 'pack for home' flow."""
+    """Pack and send in one step — the natural 'pack for home' flow.
+
+    Combines aya pack + aya send: creates the packet, signs it, and
+    publishes to the relay. This is the command most users want.
+    """
     logger.debug("dispatch: to=%s, intent=%s, as=%s", to, intent, as_)
     if instance is not None and as_ != "default":
         _emit_error(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4265,3 +4265,31 @@ class TestMaybeCreateCiWatchRepoParsing:
             _maybe_create_ci_watch()
             mock_add.assert_not_called()
             mock_watches.assert_not_called()
+
+
+# ── send/pack/dispatch help text cross-references ───────────────────────────
+
+
+class TestCommandHelpCrossReferences:
+    """Verify that send, pack, and dispatch help text cross-references each other."""
+
+    def test_send_help_mentions_dispatch(self):
+        result = CliRunner().invoke(app, ["send", "--help"])
+        assert "aya dispatch" in result.output
+
+    def test_send_help_mentions_pack(self):
+        result = CliRunner().invoke(app, ["send", "--help"])
+        assert "aya pack" in result.output
+
+    def test_pack_help_mentions_dispatch(self):
+        result = CliRunner().invoke(app, ["pack", "--help"])
+        assert "aya dispatch" in result.output
+
+    def test_pack_help_mentions_send(self):
+        result = CliRunner().invoke(app, ["pack", "--help"])
+        assert "aya send" in result.output
+
+    def test_dispatch_help_mentions_pack_and_send(self):
+        result = CliRunner().invoke(app, ["dispatch", "--help"])
+        assert "aya pack" in result.output
+        assert "aya send" in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4274,22 +4274,27 @@ class TestCommandHelpCrossReferences:
     """Verify that send, pack, and dispatch help text cross-references each other."""
 
     def test_send_help_mentions_dispatch(self):
-        result = CliRunner().invoke(app, ["send", "--help"])
+        result = runner.invoke(app, ["send", "--help"])
+        assert result.exit_code == 0, result.output
         assert "aya dispatch" in result.output
 
     def test_send_help_mentions_pack(self):
-        result = CliRunner().invoke(app, ["send", "--help"])
+        result = runner.invoke(app, ["send", "--help"])
+        assert result.exit_code == 0, result.output
         assert "aya pack" in result.output
 
     def test_pack_help_mentions_dispatch(self):
-        result = CliRunner().invoke(app, ["pack", "--help"])
+        result = runner.invoke(app, ["pack", "--help"])
+        assert result.exit_code == 0, result.output
         assert "aya dispatch" in result.output
 
     def test_pack_help_mentions_send(self):
-        result = CliRunner().invoke(app, ["pack", "--help"])
+        result = runner.invoke(app, ["pack", "--help"])
+        assert result.exit_code == 0, result.output
         assert "aya send" in result.output
 
     def test_dispatch_help_mentions_pack_and_send(self):
-        result = CliRunner().invoke(app, ["dispatch", "--help"])
+        result = runner.invoke(app, ["dispatch", "--help"])
+        assert result.exit_code == 0, result.output
         assert "aya pack" in result.output
         assert "aya send" in result.output


### PR DESCRIPTION
## Summary
- Add "See also" cross-references to `send`, `pack`, and `dispatch` help text
- Users hitting `aya send` first now discover that `aya dispatch` is the preferred command
- Each command points to the others so the relationships are clear

Closes #192

## Changes
- `src/aya/cli.py`: Expand docstrings for `pack`, `send`, and `dispatch` with cross-references
- `tests/test_cli.py`: Add 5 tests verifying help output contains cross-references

## Test plan
- [x] All 698 tests pass
- [x] Lint clean (`ruff check` + `ruff format`)
- [x] `aya send --help` mentions `dispatch` and `pack`
- [x] `aya pack --help` mentions `dispatch` and `send`
- [x] `aya dispatch --help` mentions `pack` and `send`

🤖 Generated with [Claude Code](https://claude.com/claude-code)