### PR TITLE
fix: batch quick fixes from E2E audit (#217, #219, #222)

### DIFF
--- a/.claude/commands/aya-refresh.md
+++ b/.claude/commands/aya-refresh.md
@@ -22,7 +22,12 @@ uv tool uninstall aya-ai-assist
 uv tool install --from git+https://github.com/shawnoster/aya aya-ai-assist --force
 ```
 
-3. Verify installation:
+3. Re-install hooks (picks up any format changes):
+```bash
+aya schedule install
+```
+
+4. Verify installation:
 ```bash
 which aya && aya status -f json | jq '.systems.ok'
 ```

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ uv sync
 # uv tool install .
 ```
 
+> **Python 3.14 note:** coincurve 21.0.0 does not ship a cp314 wheel and
+> the source build fails on cffi 2.0.0. Use Python 3.12 or 3.13 until
+> this is resolved upstream. Pin with: `uv tool install --python 3.12 ...`
+
 ## Quick start
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -29,9 +29,10 @@ uv sync
 # uv tool install .
 ```
 
-> **Python 3.14 note:** coincurve 21.0.0 does not ship a cp314 wheel and
-> the source build fails on cffi 2.0.0. Use Python 3.12 or 3.13 until
-> this is resolved upstream. Pin with: `uv tool install --python 3.12 ...`
+> **Python 3.14 note:** coincurve 21.0.0 does not ship a cp314 wheel, and
+> building from the coincurve 21.0.0 sdist fails with cffi 2.0.0. Use
+> Python 3.12 or 3.13 until this is resolved upstream. For example:
+> `uvx --python 3.12 --from git+https://github.com/shawnoster/aya aya`
 
 ## Quick start
 

--- a/src/aya/cli.py
+++ b/src/aya/cli.py
@@ -441,7 +441,10 @@ def init(
             f"Nostr:    [dim]{identity.nostr_public_hex[:16]}…[/dim]  "
             "[dim italic](secp256k1 · relay transport)[/dim italic]\n"
             f"Relay:    [cyan]{relay_display}[/cyan]\n\n"
-            "[dim]Share your DID with other instances you want to trust.[/dim]",
+            "[dim]Share your DID with other instances you want to trust.[/dim]\n\n"
+            "[bold]Next steps:[/bold]\n"
+            "  [cyan]aya schedule install[/cyan]    Set up hooks and cron\n"
+            "  [cyan]aya pair --peer <name>[/cyan]  Connect to another instance",
             title="aya — init",
         )
     )


### PR DESCRIPTION
## Summary
- Add next-steps guidance to `aya init` output (schedule install, pair)
- Add hook re-install step to `aya-refresh` skill
- Document Python 3.14 limitation in README

Closes #217, closes #219, closes #222

## Changes
- `src/aya/cli.py`: Init output now shows next steps
- `.claude/commands/aya-refresh.md`: Added `aya schedule install` step after reinstall
- `README.md`: Added Python 3.14 / coincurve note under Install

## Test plan
- [x] Lint passes
- [x] 170 cli tests pass
- [x] Changes are docs/output only — no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)