### PR TITLE
fix: improve error handling for missing crontab and gh CLI

### DIFF
--- a/src/aya/install.py
+++ b/src/aya/install.py
@@ -510,7 +510,8 @@ def install_scheduler(
         except FileNotFoundError:
             result.errors.append(
                 "crontab not found — skipping cron install. "
-                "On WSL, start the cron service with: sudo service cron start"
+                "Install cron/crontab and ensure the 'crontab' executable is on PATH. "
+                "On WSL, you may also need to start the service: sudo service cron start"
             )
         except subprocess.CalledProcessError as exc:
             result.errors.append(f"crontab failed: {exc}")

--- a/src/aya/install.py
+++ b/src/aya/install.py
@@ -255,7 +255,10 @@ def _build_cron_lines(aya_path: str, interval_seconds: int) -> list[str]:
 
 
 def _get_current_crontab() -> str:
-    """Read current crontab. Returns empty string if none exists."""
+    """Read current crontab. Returns empty string if none exists.
+
+    Raises FileNotFoundError if crontab is not installed (e.g. WSL without cron).
+    """
     result = subprocess.run(
         ["crontab", "-l"],  # noqa: S607
         capture_output=True,
@@ -504,6 +507,11 @@ def install_scheduler(
             result.cron_installed = installed
             result.cron_already_present = already
             result.cron_lines = lines
+        except FileNotFoundError:
+            result.errors.append(
+                "crontab not found — skipping cron install. "
+                "On WSL, start the cron service with: sudo service cron start"
+            )
         except subprocess.CalledProcessError as exc:
             result.errors.append(f"crontab failed: {exc}")
 

--- a/src/aya/scheduler/providers.py
+++ b/src/aya/scheduler/providers.py
@@ -37,7 +37,7 @@ def _get_jira_credentials() -> tuple[str, str, str]:
 
 # ── watch providers ──────────────────────────────────────────────────────────
 
-_gh_missing_warned = False
+_gh_missing_warned: bool = False
 
 
 def _run_gh(args: list[str], timeout: int = 15) -> dict[str, Any] | list[Any] | None:
@@ -63,7 +63,7 @@ def _run_gh(args: list[str], timeout: int = 15) -> dict[str, Any] | list[Any] | 
             _gh_missing_warned = True
         return None
     except (subprocess.TimeoutExpired, json.JSONDecodeError) as e:
-        logging.debug("gh command failed: %s", e)
+        logger.debug("gh command failed: %s", e)
         return None
 
 

--- a/src/aya/scheduler/providers.py
+++ b/src/aya/scheduler/providers.py
@@ -37,6 +37,8 @@ def _get_jira_credentials() -> tuple[str, str, str]:
 
 # ── watch providers ──────────────────────────────────────────────────────────
 
+_gh_missing_warned = False
+
 
 def _run_gh(args: list[str], timeout: int = 15) -> dict[str, Any] | list[Any] | None:
     """Run gh CLI and parse JSON output."""
@@ -51,7 +53,16 @@ def _run_gh(args: list[str], timeout: int = 15) -> dict[str, Any] | list[Any] | 
         if result.returncode != 0:
             return None
         return json.loads(result.stdout) if result.stdout.strip() else None
-    except (subprocess.TimeoutExpired, json.JSONDecodeError, FileNotFoundError) as e:
+    except FileNotFoundError:
+        global _gh_missing_warned  # noqa: PLW0603
+        if not _gh_missing_warned:
+            logger.warning(
+                "GitHub CLI ('gh') not installed — GitHub watch features disabled. "
+                "Install: https://cli.github.com/"
+            )
+            _gh_missing_warned = True
+        return None
+    except (subprocess.TimeoutExpired, json.JSONDecodeError) as e:
         logging.debug("gh command failed: %s", e)
         return None
 


### PR DESCRIPTION
## Summary
- Fix misleading "Could not find 'aya' on PATH" error when crontab isn't installed (WSL)
- Warn at WARNING level (once) when `gh` CLI is missing instead of silent DEBUG log

Closes #218, closes #220

## Changes
- `src/aya/install.py`: Catch `FileNotFoundError` separately for `crontab`, suggest `sudo service cron start` on WSL
- `src/aya/scheduler/providers.py`: Split `FileNotFoundError` from other exceptions, log at WARNING with install link, warn-once guard

## Test plan
- [x] All 698 tests pass
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)