### PR TITLE
feat(relay): add relay status subcommand

### DIFF
--- a/src/aya/cli.py
+++ b/src/aya/cli.py
@@ -3065,6 +3065,53 @@ def relay_remove(
     console.print(f"[dim]Saved to {profile}[/dim]")
 
 
+@relay_app.command("status")
+def relay_status(
+    as_: str = typer.Option("default", "--as", help="Local identity to act as"),
+    profile: Path = typer.Option(DEFAULT_PROFILE, help="Path to profile.json"),
+    format_: OutputFormat = typer.Option(
+        OutputFormat.AUTO, "--format", "-f", help="Output format: auto (default), text, or json"
+    ),
+) -> None:
+    """Relay health check: identity, trusted peers, relays, last poll."""
+    format_ = resolve_format(format_)
+    p = _load_profile_for_relay(profile)
+
+    # Instance label
+    instance_label = as_ if as_ != "default" else next(iter(p.instances.keys()), "default")
+
+    # Trusted peers
+    trusted_peers = [v.label for v in p.trusted_keys.values() if v.label]
+
+    # Relay URLs
+    relays = list(p.default_relays)
+
+    # Last poll per relay
+    last_checked: dict[str, str] = {}
+    if p.last_checked:
+        last_checked = {url: ts for url, ts in p.last_checked.items() if url in relays}
+
+    if format_ == OutputFormat.JSON:
+        _output_json(
+            {
+                "instance": instance_label,
+                "trusted_peers": trusted_peers,
+                "relays": relays,
+                "last_checked": last_checked,
+            }
+        )
+        return
+
+    console.print(f"Instance:       {instance_label}")
+    console.print("Trusted peers:  " + (", ".join(trusted_peers) if trusted_peers else "(none)"))
+    console.print("Relays:         " + (", ".join(relays) if relays else "(none)"))
+    if last_checked:
+        for url, ts in last_checked.items():
+            console.print(f"Last poll:      {url} → {ts}")
+    else:
+        console.print("Last poll:      (never)")
+
+
 # ── Clipboard helper ─────────────────────────────────────────────────────────
 
 

--- a/src/aya/cli.py
+++ b/src/aya/cli.py
@@ -3077,7 +3077,9 @@ def relay_status(
     format_ = resolve_format(format_)
     p = _load_profile_for_relay(profile)
 
-    # Instance label
+    # Resolve and validate the requested instance
+    _resolve_instance(p, as_)
+    # Derive display label: use as_ if explicit, otherwise the single registered instance
     instance_label = as_ if as_ != "default" else next(iter(p.instances.keys()), "default")
 
     # Trusted peers

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4209,6 +4209,32 @@ class TestRelayStatus:
         assert payload["relays"] == ["wss://relay.damus.io"]
         assert payload["last_checked"] == {"wss://relay.damus.io": "2026-04-16T12:00:00Z"}
 
+    def test_status_with_named_instance(self, profile_path: Path) -> None:
+        profile = Profile(alias="Ace", ship_mind_name="", user_name="Shawn")
+        profile.instances["work"] = Identity.generate("work")
+        profile.default_relays = ["wss://relay.example"]
+        profile.save(profile_path)
+
+        result = runner.invoke(
+            app,
+            ["relay", "status", "--profile", str(profile_path), "--as", "work", "--format", "text"],
+        )
+        assert result.exit_code == 0, result.output
+        assert "work" in result.output
+        assert "wss://relay.example" in result.output
+
+    def test_status_with_unknown_instance_errors(self, profile_path: Path) -> None:
+        profile = Profile(alias="Ace", ship_mind_name="", user_name="Shawn")
+        profile.instances["work"] = Identity.generate("work")
+        profile.instances["home"] = Identity.generate("home")
+        profile.save(profile_path)
+
+        result = runner.invoke(
+            app,
+            ["relay", "status", "--profile", str(profile_path), "--as", "nope", "--format", "text"],
+        )
+        assert result.exit_code != 0
+
     def test_status_text_no_peers_no_poll(self, profile_with_instance: Path) -> None:
         p = Profile.load(profile_with_instance)
         p.default_relays = ["wss://relay.damus.io"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4170,6 +4170,59 @@ class TestRelayRemove:
         assert payload["relays"] == []
 
 
+class TestRelayStatus:
+    def test_status_text_shows_instance_and_peers(self, profile_with_instance: Path) -> None:
+        p = Profile.load(profile_with_instance)
+        p.default_relays = ["wss://relay.damus.io", "wss://nos.lol"]
+        p.trusted_keys["home"] = TrustedKey(did="did:key:test123", label="home", nostr_pubkey=None)
+        p.last_checked = {"wss://relay.damus.io": "2026-04-16T12:00:00Z"}
+        p.save(profile_with_instance)
+
+        result = runner.invoke(
+            app,
+            ["relay", "status", "--profile", str(profile_with_instance), "--format", "text"],
+        )
+        assert result.exit_code == 0, result.output
+        assert "Instance:" in result.output
+        assert "default" in result.output
+        assert "Trusted peers:" in result.output
+        assert "home" in result.output
+        assert "wss://relay.damus.io" in result.output
+        assert "Last poll:" in result.output
+        assert "2026-04-16T12:00:00Z" in result.output
+
+    def test_status_json_shape(self, profile_with_instance: Path) -> None:
+        p = Profile.load(profile_with_instance)
+        p.default_relays = ["wss://relay.damus.io"]
+        p.trusted_keys["home"] = TrustedKey(did="did:key:test456", label="home", nostr_pubkey=None)
+        p.last_checked = {"wss://relay.damus.io": "2026-04-16T12:00:00Z"}
+        p.save(profile_with_instance)
+
+        result = runner.invoke(
+            app,
+            ["relay", "status", "--profile", str(profile_with_instance), "--format", "json"],
+        )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["instance"] == "default"
+        assert payload["trusted_peers"] == ["home"]
+        assert payload["relays"] == ["wss://relay.damus.io"]
+        assert payload["last_checked"] == {"wss://relay.damus.io": "2026-04-16T12:00:00Z"}
+
+    def test_status_text_no_peers_no_poll(self, profile_with_instance: Path) -> None:
+        p = Profile.load(profile_with_instance)
+        p.default_relays = ["wss://relay.damus.io"]
+        p.save(profile_with_instance)
+
+        result = runner.invoke(
+            app,
+            ["relay", "status", "--profile", str(profile_with_instance), "--format", "text"],
+        )
+        assert result.exit_code == 0, result.output
+        assert "(none)" in result.output
+        assert "(never)" in result.output
+
+
 # ── _maybe_create_ci_watch gh repo view parsing ─────────────────────────────
 
 


### PR DESCRIPTION
## Summary
- Add `aya relay status` command showing instance label, trusted peers, relay URLs, and last poll timestamps
- Supports `--format json` for structured output, `--as` for identity selection
- Closes the CLI gap identified in the E2E audit — the relay skill no longer needs a Python fallback

Closes #221

## Changes
- `src/aya/cli.py`: New `relay_status` command in the `relay_app` subgroup
- `tests/test_cli.py`: 3 tests — text output, JSON shape, empty peers/no poll edge case

## Test plan
- [x] All 701 tests pass
- [x] Lint clean
- [x] Text mode shows instance, peers, relays, last poll (or "(never)")
- [x] JSON mode returns structured dict with expected keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)