### PR TITLE
feat(mcp): add read, config, packets, and relay-status tools

### DIFF
--- a/src/aya/mcp_server.py
+++ b/src/aya/mcp_server.py
@@ -180,6 +180,84 @@ _TOOLS: list[types.Tool] = [
             "additionalProperties": False,
         },
     ),
+    types.Tool(
+        name="aya_read",
+        description="Read the content of a stored packet by ID or prefix.",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "packet_id": {
+                    "type": "string",
+                    "description": "Packet ID or prefix (min 8 chars).",
+                },
+                "meta": {
+                    "type": "boolean",
+                    "description": "If true, return full metadata; otherwise return content only.",
+                    "default": False,
+                },
+            },
+            "required": ["packet_id"],
+            "additionalProperties": False,
+        },
+    ),
+    types.Tool(
+        name="aya_config_set",
+        description="Set a workspace configuration value.",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "key": {
+                    "type": "string",
+                    "description": "Configuration key to set.",
+                },
+                "value": {
+                    "type": "string",
+                    "description": "Value to assign.",
+                },
+            },
+            "required": ["key", "value"],
+            "additionalProperties": False,
+        },
+    ),
+    types.Tool(
+        name="aya_config_show",
+        description="Show the current workspace configuration.",
+        inputSchema={
+            "type": "object",
+            "properties": {},
+            "additionalProperties": False,
+        },
+    ),
+    types.Tool(
+        name="aya_packets",
+        description="List stored packets, most recent first.",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum number of packets to return (default: 20).",
+                    "default": 20,
+                },
+            },
+            "additionalProperties": False,
+        },
+    ),
+    types.Tool(
+        name="aya_relay_status",
+        description="Show relay health and identity info for an instance.",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "instance": {
+                    "type": "string",
+                    "description": "Local identity to check (default: 'default').",
+                    "default": "default",
+                },
+            },
+            "additionalProperties": False,
+        },
+    ),
 ]
 
 
@@ -525,6 +603,107 @@ async def _handle_show(arguments: dict[str, Any]) -> list[types.TextContent]:
     return _text(json.loads(pkt.to_json()))
 
 
+async def _handle_read(arguments: dict[str, Any]) -> list[types.TextContent]:
+    packet_id = arguments["packet_id"]
+    meta = arguments.get("meta", False)
+
+    from aya.packet import Packet
+    from aya.paths import PACKETS_DIR
+
+    if len(packet_id) < 8:
+        return _error("Packet ID prefix must be at least 8 characters.")
+
+    if not PACKETS_DIR.exists():
+        return _error("No stored packets found.")
+
+    matches = [f for f in PACKETS_DIR.glob("*.json") if f.stem.startswith(packet_id)]
+    if not matches:
+        return _error(f"Packet '{packet_id}' not found.")
+    if len(matches) > 1:
+        return _error(f"Ambiguous prefix '{packet_id}' -- matches {len(matches)} packets.")
+
+    pkt = Packet.from_json(matches[0].read_text())
+
+    if meta:
+        return _text(
+            {
+                "id": pkt.id,
+                "intent": pkt.intent,
+                "from": pkt.from_did,
+                "sent_at": pkt.sent_at,
+                "content_type": (
+                    pkt.content_type.value
+                    if hasattr(pkt.content_type, "value")
+                    else str(pkt.content_type)
+                ),
+                "content": pkt.content,
+            }
+        )
+    return _text({"content": pkt.content})
+
+
+async def _handle_config_set(arguments: dict[str, Any]) -> list[types.TextContent]:
+    from aya.config import set_config_value
+
+    key = arguments["key"]
+    value = arguments["value"]
+    config = set_config_value(key, value)
+    return _text(config)
+
+
+async def _handle_config_show(_arguments: dict[str, Any]) -> list[types.TextContent]:
+    from aya.config import load_config
+
+    config = load_config()
+    return _text(config)
+
+
+async def _handle_packets(arguments: dict[str, Any]) -> list[types.TextContent]:
+    from aya.packet import Packet
+    from aya.paths import PACKETS_DIR
+
+    limit = arguments.get("limit", 20)
+
+    if not PACKETS_DIR.exists():
+        return _text([])
+
+    files = sorted(PACKETS_DIR.glob("*.json"), key=lambda f: f.stat().st_mtime, reverse=True)
+    files = files[:limit]
+
+    summaries = []
+    for f in files:
+        try:
+            pkt = Packet.from_json(f.read_text())
+            summaries.append(
+                {
+                    "id": pkt.id,
+                    "intent": pkt.intent,
+                    "from": pkt.from_did,
+                    "sent_at": pkt.sent_at,
+                }
+            )
+        except Exception:
+            logger.debug("Skipping unparseable packet file %s", f.name)
+    return _text(summaries)
+
+
+async def _handle_relay_status(arguments: dict[str, Any]) -> list[types.TextContent]:
+    instance = arguments.get("instance", "default")
+    profile = _load_profile()
+    local = _resolve_instance(profile, instance)
+
+    trusted = {label: tk.did for label, tk in profile.trusted_keys.items()}
+
+    result: dict[str, Any] = {
+        "instance": instance,
+        "did": local.did,
+        "relays": profile.default_relays,
+        "trusted_keys": trusted,
+        "last_checked": profile.last_checked,
+    }
+    return _text(result)
+
+
 # ── dispatcher ───────────────────────────────────────────────────────────────
 
 _HANDLERS: dict[str, Any] = {
@@ -536,6 +715,11 @@ _HANDLERS: dict[str, Any] = {
     "aya_schedule_watch": _handle_schedule_watch,
     "aya_ack": _handle_ack,
     "aya_show": _handle_show,
+    "aya_read": _handle_read,
+    "aya_config_set": _handle_config_set,
+    "aya_config_show": _handle_config_show,
+    "aya_packets": _handle_packets,
+    "aya_relay_status": _handle_relay_status,
 }
 
 

--- a/src/aya/mcp_server.py
+++ b/src/aya/mcp_server.py
@@ -236,6 +236,7 @@ _TOOLS: list[types.Tool] = [
             "properties": {
                 "limit": {
                     "type": "integer",
+                    "minimum": 1,
                     "description": "Maximum number of packets to return (default: 20).",
                     "default": 20,
                 },
@@ -662,12 +663,18 @@ async def _handle_packets(arguments: dict[str, Any]) -> list[types.TextContent]:
     from aya.packet import Packet
     from aya.paths import PACKETS_DIR
 
-    limit = arguments.get("limit", 20)
+    limit = max(int(arguments.get("limit", 20)), 1)
 
     if not PACKETS_DIR.exists():
         return _text([])
 
-    files = sorted(PACKETS_DIR.glob("*.json"), key=lambda f: f.stat().st_mtime, reverse=True)
+    def _safe_mtime(f: Any) -> float:
+        try:
+            return f.stat().st_mtime
+        except OSError:
+            return 0.0
+
+    files = sorted(PACKETS_DIR.glob("*.json"), key=_safe_mtime, reverse=True)
     files = files[:limit]
 
     summaries = []
@@ -694,12 +701,15 @@ async def _handle_relay_status(arguments: dict[str, Any]) -> list[types.TextCont
 
     trusted = {label: tk.did for label, tk in profile.trusted_keys.items()}
 
+    relays = profile.default_relays
+    last_checked = {url: ts for url, ts in profile.last_checked.items() if url in relays}
+
     result: dict[str, Any] = {
         "instance": instance,
         "did": local.did,
-        "relays": profile.default_relays,
+        "relays": relays,
         "trusted_keys": trusted,
-        "last_checked": profile.last_checked,
+        "last_checked": last_checked,
     }
     return _text(result)
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -26,6 +26,11 @@ def test_list_tools_names():
         "aya_schedule_watch",
         "aya_ack",
         "aya_show",
+        "aya_read",
+        "aya_config_set",
+        "aya_config_show",
+        "aya_packets",
+        "aya_relay_status",
     }
 
 
@@ -273,6 +278,163 @@ async def test_ack_tool(tmp_path):
     assert payload["in_reply_to"] == pkt.id
     assert "packet_id" in payload
     mock_publish.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# aya_read
+# ---------------------------------------------------------------------------
+
+
+async def test_read_tool_content_only(tmp_path):
+    """aya_read returns content only by default."""
+    from aya.packet import Packet
+
+    pkt = Packet(**{"from": "did:key:sender", "to": "did:key:receiver"}, intent="test")
+    pkt.content = "Hello world"
+    packets_dir = tmp_path / "packets"
+    packets_dir.mkdir()
+    (packets_dir / f"{pkt.id}.json").write_text(pkt.to_json())
+
+    with patch("aya.paths.PACKETS_DIR", packets_dir):
+        result = await call_tool("aya_read", {"packet_id": pkt.id[:8]})
+
+    payload = json.loads(result[0].text)
+    assert payload == {"content": "Hello world"}
+
+
+async def test_read_tool_with_meta(tmp_path):
+    """aya_read with meta=True returns full metadata."""
+    from aya.packet import Packet
+
+    pkt = Packet(**{"from": "did:key:sender", "to": "did:key:receiver"}, intent="test")
+    pkt.content = "Hello world"
+    packets_dir = tmp_path / "packets"
+    packets_dir.mkdir()
+    (packets_dir / f"{pkt.id}.json").write_text(pkt.to_json())
+
+    with patch("aya.paths.PACKETS_DIR", packets_dir):
+        result = await call_tool("aya_read", {"packet_id": pkt.id[:8], "meta": True})
+
+    payload = json.loads(result[0].text)
+    assert payload["id"] == pkt.id
+    assert payload["intent"] == "test"
+    assert payload["content"] == "Hello world"
+
+
+async def test_read_tool_short_prefix():
+    """aya_read rejects prefixes shorter than 8 chars."""
+    result = await call_tool("aya_read", {"packet_id": "abc"})
+    payload = json.loads(result[0].text)
+    assert "error" in payload
+
+
+# ---------------------------------------------------------------------------
+# aya_config_show
+# ---------------------------------------------------------------------------
+
+
+async def test_config_show_tool():
+    """aya_config_show returns current config."""
+    fake_config = {"instance_label": "home"}
+
+    with patch("aya.config.load_config", return_value=fake_config):
+        result = await call_tool("aya_config_show", {})
+
+    payload = json.loads(result[0].text)
+    assert payload["instance_label"] == "home"
+
+
+# ---------------------------------------------------------------------------
+# aya_config_set
+# ---------------------------------------------------------------------------
+
+
+async def test_config_set_tool():
+    """aya_config_set sets a value and returns updated config."""
+    fake_result = {"instance_label": "home", "foo": "bar"}
+
+    with patch("aya.config.set_config_value", return_value=fake_result):
+        result = await call_tool("aya_config_set", {"key": "foo", "value": "bar"})
+
+    payload = json.loads(result[0].text)
+    assert payload["foo"] == "bar"
+    assert payload["instance_label"] == "home"
+
+
+# ---------------------------------------------------------------------------
+# aya_packets
+# ---------------------------------------------------------------------------
+
+
+async def test_packets_tool(tmp_path):
+    """aya_packets lists stored packets."""
+    from aya.packet import Packet
+
+    packets_dir = tmp_path / "packets"
+    packets_dir.mkdir()
+
+    for i in range(3):
+        pkt = Packet(
+            **{"from": "did:key:sender", "to": "did:key:receiver"},
+            intent=f"test-{i}",
+        )
+        (packets_dir / f"{pkt.id}.json").write_text(pkt.to_json())
+
+    with patch("aya.paths.PACKETS_DIR", packets_dir):
+        result = await call_tool("aya_packets", {"limit": 2})
+
+    payload = json.loads(result[0].text)
+    assert isinstance(payload, list)
+    assert len(payload) == 2
+
+
+async def test_packets_tool_empty(tmp_path):
+    """aya_packets returns empty list when no packets dir."""
+    missing_dir = tmp_path / "no_packets"
+    with patch("aya.paths.PACKETS_DIR", missing_dir):
+        result = await call_tool("aya_packets", {})
+
+    payload = json.loads(result[0].text)
+    assert payload == []
+
+
+# ---------------------------------------------------------------------------
+# aya_relay_status
+# ---------------------------------------------------------------------------
+
+
+async def test_relay_status_tool():
+    """aya_relay_status returns relay info."""
+    from aya.identity import Identity, Profile, TrustedKey
+
+    local = Identity.generate("default")
+    peer = Identity.generate("peer")
+    profile = Profile(
+        alias="Test",
+        ship_mind_name="",
+        user_name="Tester",
+        instances={"default": local},
+        trusted_keys={
+            "peer": TrustedKey(
+                did=peer.did,
+                label="peer",
+                nostr_pubkey=peer.nostr_public_hex,
+            ),
+        },
+        ingested_ids=[],
+        default_relays=["wss://relay.example.com"],
+        last_checked={"wss://relay.example.com": "2026-04-01T10:00:00Z"},
+    )
+
+    with patch("aya.mcp_server._load_profile", return_value=profile):
+        result = await call_tool("aya_relay_status", {"instance": "default"})
+
+    payload = json.loads(result[0].text)
+    assert payload["instance"] == "default"
+    assert payload["did"] == local.did
+    assert payload["relays"] == ["wss://relay.example.com"]
+    assert "peer" in payload["trusted_keys"]
+    assert payload["last_checked"]["wss://relay.example.com"] == "2026-04-01T10:00:00Z"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add 5 new MCP tools to close gaps identified in E2E audit
- `aya_read`: packet content extraction by ID/prefix
- `aya_config_set` / `aya_config_show`: workspace config management
- `aya_packets`: packet history listing
- `aya_relay_status`: relay health check
- Skipped `aya_pair` (async/blocking — stays CLI-only)

Closes #225

## Changes
- `src/aya/mcp_server.py`: 5 new tool definitions, handlers, and dispatcher entries
- `tests/test_mcp_server.py`: 8 new tests covering all 5 tools

## Test plan
- [x] All 711 tests pass
- [x] Lint clean
- [x] Tool count updated from 8 → 13

🤖 Generated with [Claude Code](https://claude.com/claude-code)