### PR TITLE
fix(scheduler): detect system timezone instead of hardcoding America/Denver

### DIFF
--- a/src/aya/scheduler/time_utils.py
+++ b/src/aya/scheduler/time_utils.py
@@ -16,16 +16,62 @@ logger = logging.getLogger(__name__)
 
 @functools.lru_cache(maxsize=1)
 def _get_local_tz() -> ZoneInfo:
-    """Get the local timezone from AYA_TZ env var, with fallback to America/Denver.
+    """Get the local timezone from AYA_TZ env var, with system detection fallback.
+
+    Resolution order:
+    1. AYA_TZ environment variable (explicit override)
+    2. System timezone via datetime.now().astimezone().tzinfo
+    3. UTC as last resort
 
     Caching ensures consistent timezone throughout the session.
     """
-    tz_name = os.environ.get("AYA_TZ", "America/Denver").strip()
+    tz_name = os.environ.get("AYA_TZ", "").strip()
+    if tz_name:
+        try:
+            return ZoneInfo(tz_name)
+        except KeyError:
+            logging.warning("Invalid AYA_TZ %r; falling back to system timezone", tz_name)
+
+    # Detect system timezone
     try:
-        return ZoneInfo(tz_name)
-    except KeyError:
-        logging.warning("Invalid timezone %r; falling back to America/Denver", tz_name)
-        return ZoneInfo("America/Denver")
+        local_tz = datetime.now().astimezone().tzinfo
+        if local_tz is not None:
+            # Get the IANA name if available (e.g. America/Los_Angeles)
+            tz_key = getattr(local_tz, "key", None)
+            if tz_key:
+                return ZoneInfo(tz_key)
+            # Fall back to using the offset-based tzinfo directly wrapped in ZoneInfo
+            import time
+
+            if time.daylight:
+                tz_name = time.tzname[1] if time.localtime().tm_isdst else time.tzname[0]
+            else:
+                tz_name = time.tzname[0]
+            # tzname gives abbreviations like "PDT" — not valid for ZoneInfo.
+            # Use /etc/localtime or TZ env as IANA source.
+            for src in ("/etc/timezone", "/etc/localtime"):
+                try:
+                    import pathlib
+
+                    p = pathlib.Path(src)
+                    if p.is_symlink():
+                        # /etc/localtime -> ../usr/share/zoneinfo/America/Los_Angeles
+                        resolved = str(p.resolve())
+                        if "zoneinfo/" in resolved:
+                            iana = resolved.split("zoneinfo/", 1)[1]
+                            return ZoneInfo(iana)
+                    elif p.exists() and src == "/etc/timezone":
+                        iana = p.read_text().strip()
+                        if iana:
+                            return ZoneInfo(iana)
+                except Exception:  # noqa: S112
+                    continue
+            # If we got a working tzinfo from astimezone, use it directly
+            return local_tz  # type: ignore[return-value]
+    except Exception:
+        logging.warning("Could not detect system timezone; falling back to UTC")
+
+    return ZoneInfo("UTC")
 
 
 # ── alert expiry constant ────────────────────────────────────────────────────

--- a/src/aya/scheduler/time_utils.py
+++ b/src/aya/scheduler/time_utils.py
@@ -20,57 +20,43 @@ def _get_local_tz() -> ZoneInfo:
 
     Resolution order:
     1. AYA_TZ environment variable (explicit override)
-    2. System timezone via datetime.now().astimezone().tzinfo
-    3. UTC as last resort
+    2. /etc/timezone (plain text IANA name, common on Debian/Ubuntu/WSL)
+    3. /etc/localtime symlink target (common on most Linux distros)
+    4. UTC as last resort
 
-    Caching ensures consistent timezone throughout the session.
+    Always returns a proper ZoneInfo with DST rules. Caching ensures
+    consistent timezone throughout the session.
     """
+    import pathlib
+
     tz_name = os.environ.get("AYA_TZ", "").strip()
     if tz_name:
         try:
             return ZoneInfo(tz_name)
         except KeyError:
-            logging.warning("Invalid AYA_TZ %r; falling back to system timezone", tz_name)
+            logger.warning("Invalid AYA_TZ %r; falling back to system timezone", tz_name)
 
-    # Detect system timezone
+    # Try /etc/timezone (Debian/Ubuntu/WSL — plain text IANA name)
     try:
-        local_tz = datetime.now().astimezone().tzinfo
-        if local_tz is not None:
-            # Get the IANA name if available (e.g. America/Los_Angeles)
-            tz_key = getattr(local_tz, "key", None)
-            if tz_key:
-                return ZoneInfo(tz_key)
-            # Fall back to using the offset-based tzinfo directly wrapped in ZoneInfo
-            import time
-
-            if time.daylight:
-                tz_name = time.tzname[1] if time.localtime().tm_isdst else time.tzname[0]
-            else:
-                tz_name = time.tzname[0]
-            # tzname gives abbreviations like "PDT" — not valid for ZoneInfo.
-            # Use /etc/localtime or TZ env as IANA source.
-            for src in ("/etc/timezone", "/etc/localtime"):
-                try:
-                    import pathlib
-
-                    p = pathlib.Path(src)
-                    if p.is_symlink():
-                        # /etc/localtime -> ../usr/share/zoneinfo/America/Los_Angeles
-                        resolved = str(p.resolve())
-                        if "zoneinfo/" in resolved:
-                            iana = resolved.split("zoneinfo/", 1)[1]
-                            return ZoneInfo(iana)
-                    elif p.exists() and src == "/etc/timezone":
-                        iana = p.read_text().strip()
-                        if iana:
-                            return ZoneInfo(iana)
-                except Exception:  # noqa: S112
-                    continue
-            # If we got a working tzinfo from astimezone, use it directly
-            return local_tz  # type: ignore[return-value]
+        p = pathlib.Path("/etc/timezone")
+        if p.exists():
+            iana = p.read_text().strip()
+            if iana:
+                return ZoneInfo(iana)
     except Exception:
-        logging.warning("Could not detect system timezone; falling back to UTC")
+        logger.debug("Failed to read /etc/timezone")
 
+    # Try /etc/localtime symlink (most Linux distros)
+    try:
+        p = pathlib.Path("/etc/localtime")
+        resolved = str(p.resolve())
+        if "zoneinfo/" in resolved:
+            iana = resolved.split("zoneinfo/", 1)[1]
+            return ZoneInfo(iana)
+    except Exception:
+        logger.debug("Failed to resolve /etc/localtime")
+
+    logger.warning("Could not detect system timezone; falling back to UTC")
     return ZoneInfo("UTC")
 
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -54,12 +54,14 @@ def _isolate_scheduler(tmp_path, monkeypatch):
 
 class TestGetLocalTz:
     def test_default_timezone(self, monkeypatch):
-        """_get_local_tz returns America/Denver by default."""
+        """_get_local_tz detects system timezone when AYA_TZ is not set."""
         monkeypatch.delenv("AYA_TZ", raising=False)
         # Clear the cache so we get a fresh evaluation
         _get_local_tz.cache_clear()
         tz = _get_local_tz()
-        assert str(tz) == "America/Denver"
+        # Should detect the system timezone, not hardcode Denver
+        assert tz is not None
+        assert str(tz) != ""
 
     def test_custom_timezone(self, monkeypatch):
         """_get_local_tz respects AYA_TZ env var."""
@@ -76,12 +78,14 @@ class TestGetLocalTz:
         assert str(tz) == "UTC"
 
     def test_invalid_timezone_fallback(self, monkeypatch, caplog):
-        """_get_local_tz falls back to America/Denver for invalid timezone."""
+        """_get_local_tz falls back to system timezone for invalid AYA_TZ."""
         monkeypatch.setenv("AYA_TZ", "Invalid/Zone")
         _get_local_tz.cache_clear()
         tz = _get_local_tz()
-        assert str(tz) == "America/Denver"
-        assert "Invalid timezone" in caplog.text
+        # Should fall back to system tz (not Denver), or UTC as last resort
+        assert tz is not None
+        assert str(tz) != "Invalid/Zone"
+        assert "Invalid AYA_TZ" in caplog.text
 
     def test_cache_clears_with_env_var_change(self, monkeypatch):
         """_get_local_tz cache responds to AYA_TZ changes."""

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
 
 import pytest
 
@@ -53,14 +54,15 @@ def _isolate_scheduler(tmp_path, monkeypatch):
 
 
 class TestGetLocalTz:
-    def test_default_timezone(self, monkeypatch):
+    def test_default_timezone_detects_system(self, monkeypatch):
         """_get_local_tz detects system timezone when AYA_TZ is not set."""
         monkeypatch.delenv("AYA_TZ", raising=False)
-        # Clear the cache so we get a fresh evaluation
         _get_local_tz.cache_clear()
         tz = _get_local_tz()
-        # Should detect the system timezone, not hardcode Denver
-        assert tz is not None
+        # Must return a real ZoneInfo (not a fixed-offset tzinfo)
+        assert isinstance(tz, ZoneInfo)
+        # On any Linux system, should detect something (not fall through to UTC
+        # unless the system genuinely has no timezone configured)
         assert str(tz) != ""
 
     def test_custom_timezone(self, monkeypatch):
@@ -82,8 +84,8 @@ class TestGetLocalTz:
         monkeypatch.setenv("AYA_TZ", "Invalid/Zone")
         _get_local_tz.cache_clear()
         tz = _get_local_tz()
-        # Should fall back to system tz (not Denver), or UTC as last resort
-        assert tz is not None
+        # Must return a real ZoneInfo, not the invalid value
+        assert isinstance(tz, ZoneInfo)
         assert str(tz) != "Invalid/Zone"
         assert "Invalid AYA_TZ" in caplog.text
 


### PR DESCRIPTION
## Summary
- `_get_local_tz()` was hardcoded to fall back to `America/Denver` when `AYA_TZ` wasn't set
- All timestamps showed MDT regardless of actual system timezone (e.g. PDT on the west coast)
- Now detects system timezone via `/etc/localtime` symlink resolution, with UTC as last resort

## Changes
- `src/aya/scheduler/time_utils.py`: New detection chain — AYA_TZ → system timezone → UTC
- `tests/test_scheduler.py`: Updated 2 tests to match new fallback behavior

## Test plan
- [x] All 711 tests pass
- [x] `_get_local_tz()` returns `America/Los_Angeles` on this machine (correct)
- [x] `AYA_TZ` override still works
- [x] Invalid `AYA_TZ` falls back to system tz (not Denver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)