### PR TITLE
fix(aya-skill): quiet session cron output — silent logging, message-only reminders

### DIFF
--- a/.claude-plugin/skills/aya/SKILL.md
+++ b/.claude-plugin/skills/aya/SKILL.md
@@ -86,9 +86,10 @@ Full first-run bootstrap: identity, hooks, relay polling, and optional pairing.
      --idle-back-off 10m
    ```
 
-   **Output style rule for all session crons:**
+   **Output style rule for progress/logging and reminder/health session crons:**
    - Progress/logging crons: prompt must end with "Output nothing. Silence is correct."
    - Reminder/health crons: prompt must include "Output ONLY the reminder message itself — no preamble, no confirmation afterward."
+   - `relay-poll` is a special case: it may remain silent when nothing is ingested, but it may surface packet content to the user when packets are received.
 
 6. **Wire up the plugin.** Check if the user's shell profile already has a claude alias with `--plugin-dir`. If not, suggest adding:
 

--- a/.claude-plugin/skills/aya/SKILL.md
+++ b/.claude-plugin/skills/aya/SKILL.md
@@ -82,9 +82,13 @@ Full first-run bootstrap: identity, hooks, relay polling, and optional pairing.
 
    ```bash
    aya schedule recurring -m "health-break" -c "*/20 * * * *" \
-     -p "Deliver a health break reminder. Suggest standing up, stretching, getting water, and walking for at least 2 minutes. Keep it warm, brief, and varied — two sentences max." \
+     -p "Deliver a health break reminder in the Ship Mind voice. Output ONLY the reminder message itself — no preamble, no confirmation afterward. Suggest standing up, stretching, getting water, and walking for at least 2 minutes. Warm, brief, varied — two sentences max." \
      --idle-back-off 10m
    ```
+
+   **Output style rule for all session crons:**
+   - Progress/logging crons: prompt must end with "Output nothing. Silence is correct."
+   - Reminder/health crons: prompt must include "Output ONLY the reminder message itself — no preamble, no confirmation afterward."
 
 6. **Wire up the plugin.** Check if the user's shell profile already has a claude alias with `--plugin-dir`. If not, suggest adding:
 


### PR DESCRIPTION
## Summary

Session crons were producing verbose output during active Claude sessions, creating unwanted scroll in the conversation.

- **Progress/logging crons** should be fully silent — do the file work, emit nothing
- **Reminder/health crons** should output only the message itself — no preamble, no confirmation wrapper

## Changes

- Updated the `health-break` setup example prompt to follow the message-only style
- Added an explicit **Output style rule** block covering both cron types, so future setup follows the pattern

## Output style rules (now documented)

| Cron type | Rule |
|---|---|
| Progress / logging | Prompt ends with `"Output nothing. Silence is correct."` |
| Reminder / health | Prompt includes `"Output ONLY the reminder message itself — no preamble, no confirmation afterward."` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)