### PR TITLE
chore(install): remove aya log auto hooks from PostToolUse

### DIFF
--- a/src/aya/install.py
+++ b/src/aya/install.py
@@ -99,34 +99,6 @@ CANONICAL_HOOKS: dict[str, list[dict[str, Any]]] = {
                     "statusMessage": "Checking watches...",
                     "asyncRewake": True,
                 },
-                {
-                    "type": "command",
-                    "command": "aya log auto >/dev/null 2>&1 || true",
-                    "statusMessage": "",
-                    "async": True,
-                },
-            ],
-        },
-        {
-            "matcher": "Write",
-            "hooks": [
-                {
-                    "type": "command",
-                    "command": "aya log auto >/dev/null 2>&1 || true",
-                    "statusMessage": "",
-                    "async": True,
-                }
-            ],
-        },
-        {
-            "matcher": "Edit",
-            "hooks": [
-                {
-                    "type": "command",
-                    "command": "aya log auto >/dev/null 2>&1 || true",
-                    "statusMessage": "",
-                    "async": True,
-                }
             ],
         },
     ],

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -165,8 +165,8 @@ class TestCanonicalHookEntries:
     def test_post_tool_use_hook_crons_is_async(self) -> None:
         """The PostToolUse `aya hook crons` entry must be async — every tool
         call would otherwise pay a Python interpreter cold-start, blocking
-        the next tool. The sibling `aya log auto` and `aya hook watch`
-        entries are also async; the crons entry must match."""
+        the next tool. The sibling `aya hook watch` entry is also async
+        (asyncRewake); the crons entry must match."""
         post_tool_use = CANONICAL_HOOKS["PostToolUse"]
         crons_entries = [
             h


### PR DESCRIPTION
## Summary
- Remove the three \`aya log auto\` entries from the \`Bash\`, \`Write\`, and \`Edit\` \`PostToolUse\` matchers in \`CANONICAL_HOOKS\`.
- The hook is a fire-and-forget async command run outside Claude's awareness — it can only observe artifacts (new commits, new files), so the logs over-index on ship moments and miss the session texture (pivots, dead ends, decision points) that would actually be worth recording. Since the hook layer can never capture the interesting thing by construction, remove it rather than pretend otherwise.

## Changes
- \`src/aya/install.py\` — drop the three \`aya log auto\` hook entries. \`Bash\` keeps its \`aya hook watch\` entry; \`Write\` and \`Edit\` matchers disappear entirely (they had no other hooks).
- \`tests/test_install.py\` — update one docstring reference.

## Migration
Users pick up the cleanup automatically via the existing desired-state install logic in \`_install_hooks\`: the next \`aya schedule install\` replaces their \`aya\` hook entries with the new canonical set. No separate migration step is needed.

## Deferred
The \`aya log auto\` and \`aya log append\` CLI commands and the \`log.py\` module are **not** removed here. They're unused after this change (home-side skills also drop \`aya log append\` in a sibling workspace commit) but deleting the log module is a separate call and not urgent. If nothing touches it for a while, rip in a follow-up.

## Test plan
- [x] \`make lint\` passes
- [x] \`make test\` passes (711 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)