### PR TITLE
chore(deps): sync uv.lock to 1.36.0

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "aya-ai-assist"
-version = "1.29.0"
+version = "1.36.0"
 source = { editable = "." }
 dependencies = [
     { name = "base58" },


### PR DESCRIPTION
## Summary
Lockfile's `aya-ai-assist` entry drifted behind `pyproject.toml` during recent version bumps (stuck at 1.29.0 while pyproject is at 1.36.0). Any local `uv sync` regenerates it, so every checkout shows `uv.lock` as dirty.

## Changes
- `uv.lock` — bump `aya-ai-assist` version entry from 1.29.0 to 1.36.0

## Test plan
- [x] `git status` clean after commit on a fresh `uv sync`

🤖 Generated with [Claude Code](https://claude.com/claude-code)