### PR TITLE
fix(receive): remove since cursor that permanently excluded pending packets

### DIFF
--- a/src/aya/cli.py
+++ b/src/aya/cli.py
@@ -1131,22 +1131,14 @@ def receive(
         relay_urls = [relay] if relay else p.default_relays
         client = RelayClient(relay_urls, local.nostr_private_hex, local.nostr_public_hex)
 
-        # Compute since from last_checked to avoid re-scanning the full window on
-        # every poll.  60-second lookback guards against minor clock drift.
-        # Clamp to at most 7 days back so a very stale last_checked doesn't
-        # trigger an unbounded relay scan or override the relay's default window.
-        since: datetime | None = None
-        if p.last_checked:
-            now = datetime.now(UTC)
-            oldest = min(datetime.fromisoformat(v) for v in p.last_checked.values())
-            since = max(oldest - timedelta(seconds=60), now - timedelta(days=7))
-
         # Fetch pending packets for this instance; ingested_ids is the authoritative
-        # dedup mechanism and filters already-seen packets below.
+        # dedup mechanism and filters already-seen packets below.  No `since` filter
+        # is applied — the relay's default 7-day TTL window is the correct bound, and
+        # a cursor derived from last_checked can permanently exclude packets that
+        # arrived before the cursor but were never ingested (see issue #246).
         packets: list[Packet] = []
-        since_kwargs: dict = {"since": since} if since is not None else {}
         try:
-            async for packet in client.fetch_pending(**since_kwargs):
+            async for packet in client.fetch_pending():
                 packets.append(packet)
         except Exception:
             logger.exception("Relay fetch failed during receive")
@@ -1156,8 +1148,7 @@ def receive(
                 _output_json({"packets": []})
             return
 
-        # Record that we checked these relays — persist even when inbox is empty
-        # so future polls use a narrow since window rather than the full 7-day default.
+        # Record last poll time per relay for status display.
         now_check_iso = datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
         for url in relay_urls:
             p.last_checked[url] = now_check_iso

--- a/src/aya/mcp_server.py
+++ b/src/aya/mcp_server.py
@@ -415,7 +415,7 @@ async def _handle_send(arguments: dict[str, Any]) -> list[types.TextContent]:
 async def _handle_receive(arguments: dict[str, Any]) -> list[types.TextContent]:
     instance = arguments.get("instance", "default")
 
-    from datetime import UTC, datetime, timedelta
+    from datetime import UTC, datetime
 
     from aya.identity import _assert_valid_ulid
     from aya.ingest import ingest
@@ -429,17 +429,12 @@ async def _handle_receive(arguments: dict[str, Any]) -> list[types.TextContent]:
     relay_urls = profile.default_relays
     client = RelayClient(relay_urls, local.nostr_private_hex, local.nostr_public_hex)
 
-    since: datetime | None = None
-    if profile.last_checked:
-        now = datetime.now(UTC)
-        oldest = min(
-            datetime.fromisoformat(v.replace("Z", "+00:00")) for v in profile.last_checked.values()
-        )
-        since = max(oldest - timedelta(seconds=60), now - timedelta(days=7))
-
+    # No `since` filter — ingested_ids is the authoritative dedup mechanism and
+    # the relay's 7-day TTL window is the correct lower bound.  A last_checked-
+    # derived cursor permanently excludes packets that arrived before the cursor
+    # but were never ingested (see issue #246).
     packets: list[Packet] = []
-    since_kwargs: dict[str, Any] = {"since": since} if since is not None else {}
-    async for packet in client.fetch_pending(**since_kwargs):
+    async for packet in client.fetch_pending():
         packets.append(packet)
 
     now_check_iso = datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1445,15 +1445,17 @@ class TestReceive:
         saved = Profile.load(profile_with_instance)
         assert any(e["id"] == packet.id for e in saved.ingested_ids)
 
-    def test_receive_since_lookback(self, profile_with_sender: Path, sender: Identity) -> None:
-        """When last_checked is set, receive passes since = last_checked - 60s."""
+    def test_receive_no_since_filter(self, profile_with_sender: Path, sender: Identity) -> None:
+        """receive always calls fetch_pending() with no since, even when last_checked is set.
+
+        The since cursor was removed in issue #246 because it permanently excluded
+        packets that landed before last_checked - 60s but were never ingested.
+        ingested_ids is the authoritative dedup mechanism; the relay's 7-day TTL
+        window is the correct bound.
+        """
         p = Profile.load(profile_with_sender)
         packet = self._signed_packet(sender, p.instances["default"].did)
 
-        # Record a previous check time on one relay. Use a recent relative
-        # timestamp (1 hour ago) so it stays within cli.py's 7-day lookback
-        # clamp regardless of when the test runs. Round to seconds to match
-        # the iso serialization on line 1309.
         relay_url = p.default_relays[0]
         last_check_time = datetime.now(UTC).replace(microsecond=0) - timedelta(hours=1)
         p.last_checked[relay_url] = (
@@ -1475,10 +1477,7 @@ class TestReceive:
             )
 
         assert len(fetch_calls) == 1
-        called_since = fetch_calls[0][1].get("since")
-        assert called_since is not None
-        expected_since = last_check_time - timedelta(seconds=60)
-        assert called_since == expected_since
+        assert fetch_calls[0][1].get("since") is None
 
     def test_receive_last_checked_persistence(self, profile_with_sender: Path) -> None:
         """receive saves last_checked for each relay even when inbox is empty."""

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -342,6 +342,48 @@ async def test_receive_skips_cursor_when_persist_fails(tmp_path):
     assert all(entry["id"] != signed.id for entry in profile.ingested_ids)
 
 
+async def test_receive_no_since_filter(tmp_path):
+    """aya_receive calls fetch_pending() with no since, even when last_checked is set.
+
+    Regression for issue #246: the MCP handler had the same last_checked-derived
+    since cursor as cli.py receive, permanently excluding packets that arrived
+    before the cursor but were never ingested.
+    """
+    from datetime import UTC, datetime, timedelta
+
+    from aya.identity import Identity, Profile
+
+    local = Identity.generate("default")
+    profile = Profile(alias="Ace", ship_mind_name="", user_name="Shawn")
+    profile.instances["default"] = local
+    relay_url = "wss://relay.example.com"
+    profile.default_relays = [relay_url]
+    last_check_time = datetime.now(UTC).replace(microsecond=0) - timedelta(hours=1)
+    profile.last_checked[relay_url] = (
+        last_check_time.replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    )
+    profile_path = tmp_path / "profile.json"
+    profile.save(profile_path)
+
+    fetch_calls: list[tuple] = []
+
+    async def mock_fetch(*args, **kwargs):
+        fetch_calls.append((args, kwargs))
+        if False:  # pragma: no cover
+            yield  # makes this an async generator
+
+    with (
+        patch("aya.paths.PROFILE_PATH", profile_path),
+        patch("aya.mcp_server._load_profile", return_value=profile),
+        patch("aya.relay.RelayClient") as mock_cls,
+    ):
+        mock_cls.return_value.fetch_pending = mock_fetch
+        await call_tool("aya_receive", {"instance": "default"})
+
+    assert len(fetch_calls) == 1
+    assert fetch_calls[0][1].get("since") is None
+
+
 # ---------------------------------------------------------------------------
 # aya_ack
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Removes the `last_checked`-derived `since` cursor from both `aya receive` (CLI) and `aya_receive` (MCP) — both surfaces had the identical bug
- `fetch_pending()` now uses the relay's built-in 7-day TTL window; `ingested_ids` remains the authoritative dedup mechanism
- `last_checked` is still written after each poll for status display (`aya relay-status` / `aya_relay_status`)

## Problem

`aya receive` and `aya_receive` computed a `since` filter from `last_checked - 60s` to narrow relay fetches. Each successful poll advanced `last_checked` to `now`. Any packet whose Nostr `created_at` fell before `last_checked - 60s` was permanently excluded from future polls — even though `aya inbox` (which never applies a `since` filter) correctly surfaced the same packets as pending.

The MCP path (`mcp_server.py`) was copy-pasted from the CLI path during the refactor in #244 and carried the bug forward independently.

Closes #246.

## Test plan

- [ ] `test_receive_no_since_filter` (CLI) — verifies `fetch_pending()` is called without `since` even when `last_checked` is set
- [ ] `test_receive_no_since_filter` (MCP) — same invariant for `aya_receive`
- [ ] All 250 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)