### PR TITLE
docs(skills): wiring patterns, relay phrases, editable refresh

### DIFF
--- a/.claude-plugin/skills/aya/SKILL.md
+++ b/.claude-plugin/skills/aya/SKILL.md
@@ -121,14 +121,14 @@ Setup is **mostly CLI-only** — no MCP tools cover `aya init`,
    - Reminder/health crons: prompt must include "Output ONLY the reminder message itself — no preamble, no confirmation afterward."
    - `relay-poll` is a special case: it may remain silent when nothing is ingested, but it may surface packet content to the user when packets are received.
 
-6. **Wire up the skills.** Two patterns work — pick whichever the workspace already uses:
+6. **Wire up the skills.** Two patterns work — pick whichever the consuming workspace uses (the aya repo itself doesn't ship the wiring):
 
-   - **Symlink pattern (home machine convention).** If the workspace has a `Makefile` with a `link-skills` target (this workspace does), symlink each skill's `SKILL.md` into `~/.claude/commands/`. The home machine wires `dev/skills/{aya,relay}/` as symlinks into `dev/code/aya/.claude-plugin/skills/{aya,relay}/`, then `make link-skills` exposes them as flat slash commands. SessionStart hook keeps the links fresh.
-   - **Plugin-dir alias (portable).** If there's no symlink workflow:
+   - **Symlink pattern.** If the consuming workspace has its own `Makefile` with a `link-skills` target, symlink each skill's `SKILL.md` into `~/.claude/commands/`. Typical wiring: `<workspace>/skills/{aya,relay}/` are symlinks into the aya repo's `.claude-plugin/skills/{aya,relay}/`, and `make link-skills` exposes them as flat slash commands. A SessionStart hook can keep the links fresh.
+   - **Plugin-dir alias (portable, no Makefile needed).** If there's no symlink workflow:
      ```bash
      alias claude='claude --plugin-dir /path/to/aya'
      ```
-     Adjust the path to the local clone. Loads `/aya` and `/relay` under the plugin namespace.
+     Adjust the path to the local aya clone. Loads `/aya` and `/relay` under the plugin namespace.
 
 7. **Offer pairing.** Ask: "Do you want to pair with another machine now?" If yes, hand off to verb 2 (Pair).
 

--- a/.claude-plugin/skills/aya/SKILL.md
+++ b/.claude-plugin/skills/aya/SKILL.md
@@ -399,6 +399,7 @@ Add a watch on a GitHub PR (or other target) with sensible defaults.
 
 - For PRs the user just opened or is reviewing, default to `--remove-when merged_or_closed` so the watch cleans itself up.
 - If the user says "let me know when it's approved", add `--condition approved_or_merged`.
+- Jira watches require `ATLASSIAN_*` env vars to be set. If they're missing, tell the user to run `op-load-env` or set them manually.
 - Watch IDs support prefix matching for later dismiss/snooze operations.
 
 ---

--- a/.claude-plugin/skills/aya/SKILL.md
+++ b/.claude-plugin/skills/aya/SKILL.md
@@ -265,7 +265,7 @@ verification.
 ### Detect install source first
 
 Before reinstalling, check whether the current install is editable from
-a local source clone (the home-instance default per `AGENTS.md`):
+a local source clone (common when developing aya itself):
 
 ```bash
 cat ~/.local/share/uv/tools/aya-ai-assist/uv-receipt.toml 2>/dev/null

--- a/.claude-plugin/skills/aya/SKILL.md
+++ b/.claude-plugin/skills/aya/SKILL.md
@@ -356,6 +356,7 @@ Add a watch on a GitHub PR (or other target) with sensible defaults.
    | Target pattern | Provider |
    |---|---|
    | `owner/repo#N` or GitHub URL | `github-pr` |
+   | `PROJ-123` (Jira-style key) | `jira-ticket` |
 
 3. **Set defaults.** For GitHub PRs:
    - `--message`: "PR {number} — {title}" (fetch title via `gh pr view {number} --json title -q .title`)

--- a/.claude-plugin/skills/aya/SKILL.md
+++ b/.claude-plugin/skills/aya/SKILL.md
@@ -279,14 +279,14 @@ run **the GitHub path**.
 
 ### Editable path (local source clone)
 
-When the receipt points at a live local clone — typically
-`/home/shawn/dev/code/aya`:
+When the receipt points at a live local clone, let `<aya-clone>`
+denote the path read from the receipt (e.g. `~/dev/code/aya`):
 
 1. **Pull the clone up to date** (refresh = "get the latest"):
 
    ```bash
-   git -C /home/shawn/dev/code/aya status --porcelain
-   git -C /home/shawn/dev/code/aya pull --ff-only
+   git -C <aya-clone> status --porcelain
+   git -C <aya-clone> pull --ff-only
    ```
 
    If `status --porcelain` shows uncommitted changes, stop and ask the
@@ -296,7 +296,7 @@ When the receipt points at a live local clone — typically
 2. **Reinstall editable** (re-syncs deps from `pyproject.toml`):
 
    ```bash
-   uv tool install --editable /home/shawn/dev/code/aya --reinstall
+   uv tool install --editable <aya-clone> --reinstall
    ```
 
 3. Continue at **Common steps** below.

--- a/.claude-plugin/skills/aya/SKILL.md
+++ b/.claude-plugin/skills/aya/SKILL.md
@@ -121,13 +121,14 @@ Setup is **mostly CLI-only** — no MCP tools cover `aya init`,
    - Reminder/health crons: prompt must include "Output ONLY the reminder message itself — no preamble, no confirmation afterward."
    - `relay-poll` is a special case: it may remain silent when nothing is ingested, but it may surface packet content to the user when packets are received.
 
-6. **Wire up the plugin.** Check if the user's shell profile already has a claude alias with `--plugin-dir`. If not, suggest adding:
+6. **Wire up the skills.** Two patterns work — pick whichever the workspace already uses:
 
-   ```bash
-   alias claude='claude --plugin-dir /path/to/aya'
-   ```
-
-   Adjust the path to wherever aya is cloned. This makes `/aya` and `/relay` skills available globally.
+   - **Symlink pattern (home machine convention).** If the workspace has a `Makefile` with a `link-skills` target (this workspace does), symlink each skill's `SKILL.md` into `~/.claude/commands/`. The home machine wires `dev/skills/{aya,relay}/` as symlinks into `dev/code/aya/.claude-plugin/skills/{aya,relay}/`, then `make link-skills` exposes them as flat slash commands. SessionStart hook keeps the links fresh.
+   - **Plugin-dir alias (portable).** If there's no symlink workflow:
+     ```bash
+     alias claude='claude --plugin-dir /path/to/aya'
+     ```
+     Adjust the path to the local clone. Loads `/aya` and `/relay` under the plugin namespace.
 
 7. **Offer pairing.** Ask: "Do you want to pair with another machine now?" If yes, hand off to verb 2 (Pair).
 
@@ -258,11 +259,51 @@ Run a full aya readiness check and surface anything actionable.
 ## 4. Refresh
 
 Refresh is **CLI-only** — `uv tool` installer commands and
-`aya schedule install` have no MCP equivalents. Uninstall the current
-aya installation and reinstall the latest version from GitHub, with
+`aya schedule install` have no MCP equivalents. Reinstall aya, with
 verification.
 
-Run these commands in sequence:
+### Detect install source first
+
+Before reinstalling, check whether the current install is editable from
+a local source clone (the home-instance default per `AGENTS.md`):
+
+```bash
+cat ~/.local/share/uv/tools/aya-ai-assist/uv-receipt.toml 2>/dev/null
+```
+
+If the receipt has `editable = "/path/to/aya"` pointing at an existing
+directory, run **the editable path** below — clobbering it with a
+GitHub install kills "source edits are live without reinstall." If the
+receipt is missing, points at a dead path, or has no `editable` flag,
+run **the GitHub path**.
+
+### Editable path (local source clone)
+
+When the receipt points at a live local clone — typically
+`/home/shawn/dev/code/aya`:
+
+1. **Pull the clone up to date** (refresh = "get the latest"):
+
+   ```bash
+   git -C /home/shawn/dev/code/aya status --porcelain
+   git -C /home/shawn/dev/code/aya pull --ff-only
+   ```
+
+   If `status --porcelain` shows uncommitted changes, stop and ask the
+   user before pulling. Editable installs run against the working tree;
+   pulling could surprise in-flight work.
+
+2. **Reinstall editable** (re-syncs deps from `pyproject.toml`):
+
+   ```bash
+   uv tool install --editable /home/shawn/dev/code/aya --reinstall
+   ```
+
+3. Continue at **Common steps** below.
+
+### GitHub path (no local clone)
+
+When the receipt is missing or non-editable:
 
 1. **Uninstall current version:**
 
@@ -276,13 +317,17 @@ Run these commands in sequence:
    uv tool install --from git+https://github.com/shawnoster/aya aya-ai-assist --force
    ```
 
-3. **Re-install hooks** (picks up any format changes):
+3. Continue at **Common steps** below.
+
+### Common steps (both paths)
+
+4. **Re-install hooks** (picks up any format changes):
 
    ```bash
    aya schedule install
    ```
 
-4. **Verify installation:**
+5. **Verify installation:**
 
    ```bash
    which aya && aya status -f json | jq '.systems.ok'
@@ -311,7 +356,6 @@ Add a watch on a GitHub PR (or other target) with sensible defaults.
    | Target pattern | Provider |
    |---|---|
    | `owner/repo#N` or GitHub URL | `github-pr` |
-   | `PROJ-123` (Jira-style key) | `jira-ticket` |
 
 3. **Set defaults.** For GitHub PRs:
    - `--message`: "PR {number} — {title}" (fetch title via `gh pr view {number} --json title -q .title`)
@@ -354,7 +398,6 @@ Add a watch on a GitHub PR (or other target) with sensible defaults.
 
 - For PRs the user just opened or is reviewing, default to `--remove-when merged_or_closed` so the watch cleans itself up.
 - If the user says "let me know when it's approved", add `--condition approved_or_merged`.
-- Jira watches require `ATLASSIAN_*` env vars to be set. If they're missing, tell the user to run `op-load-env` or set them manually.
 - Watch IDs support prefix matching for later dismiss/snooze operations.
 
 ---

--- a/.claude-plugin/skills/relay/SKILL.md
+++ b/.claude-plugin/skills/relay/SKILL.md
@@ -4,10 +4,11 @@ description: >
   Manage communication between instances and peers via the aya relay.
   Covers checking inbox, reading packets, replying, sending new messages,
   and showing relay status. Invoke when the user says "check the relay",
-  "any packets", "send to home", "send this to work", "tell Sean",
-  "pack this up", "ask work", "reply to that", "what did home say",
-  "relay status", "anything new?", or any equivalent. Infers intent
-  and recipient from context. Auto-polls after every send.
+  "any packets", "send to home", "send this home", "pack for home",
+  "send this to work", "tell Sean", "pack this up", "ask work",
+  "reply to that", "what did home say", "relay status", "anything new?",
+  or any equivalent. Infers intent and recipient from context. Auto-polls
+  after every send.
 argument-hint: "[check | read <id> | reply <id> | send [<peer>] [<intent>] | status]"
 ---
 


### PR DESCRIPTION
## Summary

Three documentation cleanups to the aya/relay skills, surfaced by a 2026-04-24 harness audit on the home machine:

- **Aya skill, step 6 (Wire up the skills).** Previously taught only the `--plugin-dir` alias pattern. The home workspace actually wires aya/relay via `make link-skills` symlinks. Step now documents both patterns so a fresh setup matches whichever convention the workspace uses.
- **Aya skill, step 4 (Refresh).** Adds an install-source detection step before reinstalling. If the install receipt (`~/.local/share/uv/tools/aya-ai-assist/uv-receipt.toml`) shows an editable install pointing at a live local clone, refresh now does `git pull --ff-only` + `uv tool install --editable --reinstall` instead of clobbering it with a GitHub install. The home machine runs editable from `~/dev/code/aya`; the previous flow would have killed "source edits are live without reinstall." (These edits were already sitting in the working tree from a prior parallel-agent session — included here so they don't keep drifting.)
- **Relay skill, invocation phrases.** Adds "send this home" and "pack for home" to the relay skill's trigger list. The home workspace just retired its `pack-for-home` skill (a thin wrapper over `/relay send home`); these phrases now route unambiguously to `/relay`.

## Test plan

- [ ] On a fresh-setup walkthrough, verify both wiring patterns lead to working `/aya` and `/relay` slash commands
- [ ] On the home machine, run `/aya refresh` and confirm the editable path triggers (receipt detects editable, `git pull` runs, `uv tool install --editable --reinstall` runs, no clobber to the GitHub URL)
- [ ] Say "pack this up" / "send this home" in a session, confirm `/relay` fires (not the deleted `pack-for-home`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)