### PR TITLE
chore(cli): tier 2 consolidation — drop pack, show, schedule check

### DIFF
--- a/.claude-plugin/skills/relay/SKILL.md
+++ b/.claude-plugin/skills/relay/SKILL.md
@@ -48,11 +48,10 @@ inline with each verb below. Fall back to the CLI when any of these apply:
 MCP tools that act on a local identity (`aya_receive`, `aya_inbox`,
 `aya_send`, `aya_ack`, `aya_relay_status`) take `instance=<label>`
 where the CLI takes `--as <label>`. Other MCP tools (`aya_read`,
-`aya_show`, `aya_packets`, `aya_status`, `aya_schedule_*`,
-`aya_config_*`) don't take an identity argument — they act on local
-state or a specific packet ID. `aya_receive` auto-ingests trusted
-packets by default, so no `--auto-ingest`/`--skip-untrusted`
-equivalents are needed.
+`aya_packets`, `aya_status`, `aya_schedule_*`, `aya_config_*`) don't
+take an identity argument — they act on local state or a specific
+packet ID. `aya_receive` auto-ingests trusted packets by default, so
+no `--auto-ingest`/`--skip-untrusted` equivalents are needed.
 
 ---
 
@@ -179,7 +178,8 @@ surface you called:
 - **MCP `aya_read(meta=true)`** returns
   `{id, intent, from, sent_at, content_type, content}`. The `content`
   field is the raw packet content (no extraction). No `in_reply_to`
-  field — use `aya_show(packet_id=...)` if you need the full envelope.
+  field — read the packet file under `~/.aya/packets/<id>.json`
+  directly if you need the full signed envelope.
 - **CLI `aya read --meta --format json`** returns
   `{id, body, from, sent_at, intent, in_reply_to}`. The `body` field
   is already *extracted* text (opener+context+questions for seeds,
@@ -531,7 +531,7 @@ relay state.
 |---|---|---|
 | `aya receive` returns `{"packets": []}` but you expect one | Peer hasn't sent yet, or relay propagation lag | Tell user to ping the peer; wait 30s and retry |
 | `WARNING:aya.packet:DID-based signature verification failed for packet <id>` on stderr | Bad signature; packet is **discarded** by aya, never appears in the JSON output (and not as `ingested:false`) | Surface to user; run `aya drop <id>` to stop the resurface; sender must re-send to retry |
-| `aya show <id>` returns `PACKET_NOT_FOUND` | Packet not yet ingested | Run verb 1 (Check) first |
+| `aya read <id>` returns `PACKET_NOT_FOUND` | Packet not yet ingested | Run verb 1 (Check) first |
 | `aya send` errors with `Unknown recipient '<label>'. Available: ...` | `--to <peer>` not in `trusted_keys` | Run `aya pair` to connect, or `aya trust <did> --peer <label>` |
 | `aya send` errors with `No Nostr pubkey found for recipient. Pair first.` | Trust entry exists but lacks `nostr_pubkey` field | Re-pair via `aya pair` to populate the pubkey |
 | Interactive shell errors before aya runs | Shell function shadowing the binary | Check `declare -F aya`; unset if found |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@
 
 ### Removed
 
+- `aya pack` — `aya send` is the canonical pack-and-publish flow. The pack
+  command had no callers in skills, hooks, or MCP — its help even redirected
+  users to `send`. If you need to build a packet without publishing, use
+  `aya send --dry-run` or build the JSON manually and use `aya send-raw`.
+- `aya show` — collapsed into `aya read`. Pass `--panel` to `read` for the
+  boxed display the old `show` produced. The MCP `aya_show` tool is removed
+  with the same migration: `aya_read(meta=true)` returns the structured
+  fields, and reading the packet file at `~/.aya/packets/<id>.json` gives
+  the full signed envelope.
+- `aya schedule check` — partial reimplementation of `pending` and `alerts`.
+  Use `aya schedule pending` (the SessionStart payload) for due reminders
+  + actionable alerts, or `aya schedule alerts [--mark-seen]` for the
+  alert queue alone.
 - `aya schedule poll` — replaced by `aya schedule tick`, which already calls
   `run_poll` internally. The command had been documented as legacy since the
   unified tick refactor; nothing in skills, hooks, or the system crontab

--- a/README.md
+++ b/README.md
@@ -250,13 +250,11 @@ After editing any skill file in the aya repo, run `/reload-plugins` in your sess
 | `aya init` | Generate identity keypair for this instance |
 | `aya pair` | Pair two instances via short-lived relay code |
 | `aya trust` | Manually trust a DID |
-| `aya pack` | Create a signed knowledge packet (writes file; doesn't publish) |
-| `aya send` | Pack + send in one step (no temp file) |
+| `aya send` | Build, sign, and publish a knowledge packet to a Nostr relay |
 | `aya send-raw` | Publish a pre-built packet file to a Nostr relay |
 | `aya inbox` | List pending (un-ingested) packets |
 | `aya receive` | Review and ingest packets from the relay |
-| `aya show` | Show full content of an ingested packet |
-| `aya read` | Read content of a stored packet (with `--meta` for headers) |
+| `aya read` | Read the body of a stored packet (`--meta` for headers, `--panel` for boxed display) |
 | `aya ack` | Acknowledge a received packet (sends a reply back) |
 | `aya drop` | Delete an ingested packet from local storage |
 | `aya packets` | List stored packets, most recent first |
@@ -269,7 +267,6 @@ After editing any skill file in the aya repo, run `/reload-plugins` in your sess
 | `aya schedule activity` | Record user activity — resets the idle back-off timer |
 | `aya schedule is-idle` | Check whether the session is currently idle |
 | `aya schedule list` | List scheduled items |
-| `aya schedule check` | Check for due reminders and alerts |
 | `aya schedule dismiss` | Dismiss a scheduled item or alert (prefix match OK) |
 | `aya schedule snooze` | Snooze a reminder until a given time |
 | `aya schedule alerts` | Show alerts from the background watcher |

--- a/src/aya/cli.py
+++ b/src/aya/cli.py
@@ -2297,9 +2297,12 @@ def read(
     # Text mode — always render as a string via _extract_body.
     body = _extract_body(packet.content, packet.content_type)
     if panel:
+        # Wrap in Text() so packet bodies containing `[...]` sequences are
+        # not interpreted as Rich markup. Mirrors the non-panel path's
+        # markup=False / highlight=False behaviour.
         console.print(
             Panel(
-                body,
+                Text(body),
                 title=f"{packet.intent}  ·  {packet.id[:8]}",
                 subtitle=f"from {packet.from_did[:30]}…  ·  {packet.sent_at[:10]}",
             )

--- a/src/aya/cli.py
+++ b/src/aya/cli.py
@@ -54,7 +54,6 @@ from aya.scheduler import (
     add_recurring,
     add_reminder,
     add_watch,
-    check_due,
     dismiss_alert,
     dismiss_item,
     format_pending,
@@ -489,84 +488,6 @@ def trust(
         )
 
 
-# ── pack ──────────────────────────────────────────────────────────────────────
-
-
-@app.command()
-def pack(
-    to: str = typer.Option(..., help="Recipient label (home) or DID"),
-    intent: str = typer.Option(..., help="What is this packet and why"),
-    files: list[Path] = typer.Option([], help="Files to include"),
-    context: str = typer.Option(None, help="Annotation for the receiving assistant"),
-    seed: bool = typer.Option(False, help="Create a conversation seed instead of content"),
-    opener: str = typer.Option(None, help="[seed] Opening question for the receiving assistant"),
-    out: Path = typer.Option(None, help="Write packet JSON to file (default: stdout)"),
-    as_: str = typer.Option("default", "--as", help="Local identity to act as"),
-    conflict: ConflictStrategy = typer.Option(
-        ConflictStrategy.LAST_WRITE_WINS, help="Conflict resolution strategy"
-    ),
-    profile: Path = typer.Option(DEFAULT_PROFILE),
-    format_: OutputFormat = typer.Option(
-        OutputFormat.AUTO, "--format", "-f", help="Output format: auto (default), text, or json"
-    ),
-) -> None:
-    """Pack a knowledge packet ready to send.
-
-    To pack and send in one step: aya send --to <label> --intent "..."
-    See also: aya send-raw (send a pre-built packet file)
-    """
-    format_ = resolve_format(format_)
-    p = _load_profile(profile)
-    local = _resolve_instance(p, as_)
-
-    # Resolve recipient DID
-    to_did, _to_label = _resolve_did(to, p)
-
-    if seed:
-        if not opener:
-            _emit_error(ErrorCode.INVALID_ARGUMENT, "--opener required for seed packets.")
-        packet = Packet.as_seed(
-            from_did=local.did,
-            to_did=to_did,
-            intent=intent,
-            opener=opener,
-            context_summary=context or "",
-        )
-    elif files:
-        packet = Packet.from_files(
-            paths=[str(f) for f in files],
-            from_did=local.did,
-            to_did=to_did,
-            intent=intent,
-            context=context,
-        )
-    else:
-        content = sys.stdin.read()
-        packet = Packet(
-            **{"from": local.did, "to": to_did},
-            intent=intent,
-            context=context,
-            content_type=ContentType.MARKDOWN,
-            content=content,
-            conflict_strategy=conflict,
-        )
-
-    signed = packet.sign(local)
-    json_output = signed.to_json()
-
-    if out:
-        out.write_text(json_output)
-
-    if format_ == OutputFormat.JSON:
-        _output_json(json.loads(json_output))
-        raise typer.Exit(0)
-
-    if not out:
-        sys.stdout.write(json_output)
-    else:
-        console.print(f"[green]✓[/green] Packet written to [cyan]{out}[/cyan]")
-
-
 # ── send-raw ──────────────────────────────────────────────────────────────────
 
 
@@ -591,8 +512,6 @@ def send_raw(
 
     This sends a pre-built packet file. To compose and send in one step:
       aya send --to <label> --intent "..."
-
-    See also: aya pack (create a packet without sending)
     """
     logger.debug("send-raw: packet_file=%s, as=%s", packet_file, as_)
     format_ = resolve_format(format_)
@@ -708,8 +627,8 @@ def send_cmd(
 ) -> None:
     """Pack and send in one step — the natural 'pack for home' flow.
 
-    Combines aya pack + aya send-raw: creates the packet, signs it, and
-    publishes to the relay. This is the command most users want.
+    Builds the packet, signs it, and publishes to the relay. This is the
+    command most users want. For a pre-built packet file, see send-raw.
     """
     logger.debug("send: to=%s, intent=%s, as=%s", to, intent, as_)
     format_ = resolve_format(format_)
@@ -1632,38 +1551,6 @@ def schedule_list(
         _display_items(items)
 
 
-@schedule_app.command("check")
-def schedule_check(
-    format_: OutputFormat = typer.Option(
-        OutputFormat.AUTO, "--format", "-f", help="Output format: auto (default), text, or json"
-    ),
-) -> None:
-    """Check for due reminders and alerts."""
-    format_ = resolve_format(format_)
-    due_items, unseen = check_due()
-
-    if format_ == OutputFormat.JSON:
-        _output_json({"due": due_items, "alerts": unseen})
-        return
-
-    if not due_items and not unseen:
-        console.print("[dim]Nothing due. No alerts.[/dim]")
-        return
-
-    if due_items:
-        console.print(f"\n  [bold]⏰ {len(due_items)} reminder(s) due:[/bold]")
-        for r in due_items:
-            due_dt = datetime.fromisoformat(r["due_at"])
-            console.print(
-                f"    🔴 {r['id'][:8]}  {due_dt.strftime('%I:%M %p')}  {r['message'][:55]}"
-            )
-
-    if unseen:
-        console.print(f"\n  [bold]🔔 {len(unseen)} alert(s):[/bold]")
-        for a in unseen:
-            console.print(f"    📢 {a['source_item_id'][:8]}  {a['message'][:60]}")
-
-
 @schedule_app.command("dismiss")
 def schedule_dismiss(
     item_id: str = typer.Argument(help="Item ID (prefix match ok)"),
@@ -2300,58 +2187,6 @@ def _resolve_nostr_pubkey(did: str, profile: Profile) -> str | None:
     return None
 
 
-# ── show ──────────────────────────────────────────────────────────────────────
-
-
-@app.command()
-def show(
-    packet_id: str = typer.Argument(help="Packet ID or prefix (min 8 chars)"),
-    format_: OutputFormat = typer.Option(OutputFormat.AUTO, "--format", "-f", help="Output format"),
-) -> None:
-    """Show the content of a previously ingested packet."""
-    from aya.paths import PACKETS_DIR
-
-    format_ = resolve_format(format_)
-
-    if len(packet_id) < 8:
-        _emit_error(ErrorCode.INVALID_ARGUMENT, "Packet ID prefix must be at least 8 characters.")
-
-    # Find matching packet files
-    if not PACKETS_DIR.exists():
-        _emit_error(ErrorCode.PACKET_NOT_FOUND, "No ingested packets found.")
-
-    matches = [f for f in PACKETS_DIR.glob("*.json") if f.stem.startswith(packet_id)]
-    if not matches:
-        _emit_error(
-            ErrorCode.PACKET_NOT_FOUND,
-            f"Packet '{packet_id}' not found.",
-            {"packet_id": packet_id},
-        )
-    if len(matches) > 1:
-        _emit_error(
-            ErrorCode.AMBIGUOUS_PREFIX,
-            f"Ambiguous prefix — matches {len(matches)} packets.",
-            {"packet_id": packet_id, "matches": len(matches)},
-        )
-
-    from aya.packet import Packet
-
-    packet = Packet.from_json(matches[0].read_text())
-
-    if format_ == OutputFormat.JSON:
-        _output_json(json.loads(packet.to_json()))
-        raise typer.Exit(0)
-
-    # Rich text display
-    console.print(
-        Panel(
-            str(packet.content),
-            title=f"{packet.intent}  ·  {packet.id[:8]}",
-            subtitle=f"from {packet.from_did[:30]}…  ·  {packet.sent_at[:10]}",
-        )
-    )
-
-
 # ── read ──────────────────────────────────────────────────────────────────────
 
 
@@ -2396,13 +2231,18 @@ def _extract_body(content: object, content_type: ContentType | None = None) -> s
 def read(
     packet_id: str = typer.Argument(help="Packet ID or prefix (min 8 chars)"),
     meta: bool = typer.Option(False, "--meta", help="Also print packet metadata header"),
+    panel: bool = typer.Option(
+        False, "--panel", help="Render the body in a boxed Rich panel with title/subtitle"
+    ),
     format_: OutputFormat = typer.Option(OutputFormat.AUTO, "--format", "-f", help="Output format"),
 ) -> None:
     """Read a previously ingested packet — extracts body without dumping the envelope JSON.
 
     For seed packets, prints the opener (and context_summary, open_questions
     if present). For content packets, prints the content directly. Use
-    ``--meta`` to also print id/from/sent_at/intent header.
+    ``--meta`` to also print id/from/sent_at/intent header, or ``--panel`` to
+    render the body in a boxed display. ``--panel`` is ignored under
+    ``--format json``.
     """
     from aya.paths import PACKETS_DIR
 
@@ -2456,6 +2296,15 @@ def read(
 
     # Text mode — always render as a string via _extract_body.
     body = _extract_body(packet.content, packet.content_type)
+    if panel:
+        console.print(
+            Panel(
+                body,
+                title=f"{packet.intent}  ·  {packet.id[:8]}",
+                subtitle=f"from {packet.from_did[:30]}…  ·  {packet.sent_at[:10]}",
+            )
+        )
+        return
     if meta:
         console.print(f"[bold]{packet.intent}[/bold]  ·  {packet.id[:12]}")
         console.print(f"[dim]from {packet.from_did[:30]}…  ·  {packet.sent_at[:16]}[/dim]")

--- a/src/aya/mcp_server.py
+++ b/src/aya/mcp_server.py
@@ -166,21 +166,6 @@ _TOOLS: list[types.Tool] = [
         },
     ),
     types.Tool(
-        name="aya_show",
-        description="Show the full content of a previously ingested packet by ID or prefix.",
-        inputSchema={
-            "type": "object",
-            "properties": {
-                "packet_id": {
-                    "type": "string",
-                    "description": "Packet ID or prefix (min 8 chars).",
-                },
-            },
-            "required": ["packet_id"],
-            "additionalProperties": False,
-        },
-    ),
-    types.Tool(
         name="aya_read",
         description="Read the content of a stored packet by ID or prefix.",
         inputSchema={
@@ -594,28 +579,6 @@ async def _handle_ack(arguments: dict[str, Any]) -> list[types.TextContent]:
     return _text({"packet_id": signed.id, "event_id": event_id, "in_reply_to": full_packet_id})
 
 
-async def _handle_show(arguments: dict[str, Any]) -> list[types.TextContent]:
-    packet_id = arguments["packet_id"]
-
-    from aya.packet import Packet
-    from aya.paths import PACKETS_DIR
-
-    if len(packet_id) < 8:
-        return _error("Packet ID prefix must be at least 8 characters.")
-
-    if not PACKETS_DIR.exists():
-        return _error("No ingested packets found.")
-
-    matches = [f for f in PACKETS_DIR.glob("*.json") if f.stem.startswith(packet_id)]
-    if not matches:
-        return _error(f"Packet '{packet_id}' not found.")
-    if len(matches) > 1:
-        return _error(f"Ambiguous prefix '{packet_id}' -- matches {len(matches)} packets.")
-
-    pkt = Packet.from_json(matches[0].read_text())
-    return _text(json.loads(pkt.to_json()))
-
-
 async def _handle_read(arguments: dict[str, Any]) -> list[types.TextContent]:
     packet_id = arguments["packet_id"]
     meta = arguments.get("meta", False)
@@ -736,7 +699,6 @@ _HANDLERS: dict[str, Any] = {
     "aya_schedule_remind": _handle_schedule_remind,
     "aya_schedule_watch": _handle_schedule_watch,
     "aya_ack": _handle_ack,
-    "aya_show": _handle_show,
     "aya_read": _handle_read,
     "aya_config_set": _handle_config_set,
     "aya_config_show": _handle_config_show,

--- a/src/aya/scheduler/__init__.py
+++ b/src/aya/scheduler/__init__.py
@@ -9,7 +9,6 @@ Usage (via CLI):
     aya schedule watch   jira-query "project=CSD AND created>=-1d" -m "New CSD tickets"
     aya schedule watch   jira-ticket CSD-225 -m "Ticket status changed"
     aya schedule list    [--all] [--type TYPE]
-    aya schedule check   [--format json]
     aya schedule dismiss <id>
     aya schedule snooze  <id> --until "in 1 hour"
     aya schedule tick    [--quiet]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -328,194 +328,6 @@ class TestPair:
         assert trusted_keys["guild-shawnoster"]["did"] == initiator_identity.did
 
 
-class TestPack:
-    def test_pack_produces_json_to_file(self, profile_with_trusted: Path, tmp_path: Path) -> None:
-        out_file = tmp_path / "packet.json"
-        p = Profile.load(profile_with_trusted)
-        home_did = p.trusted_keys["home"].did
-
-        result = runner.invoke(
-            app,
-            [
-                "pack",
-                "--to",
-                home_did,
-                "--intent",
-                "Test pack from work",
-                "--out",
-                str(out_file),
-                "--profile",
-                str(profile_with_trusted),
-                "--format",
-                "text",
-            ],
-            input="Some content\n",
-        )
-        assert result.exit_code == 0, result.output
-        assert out_file.exists()
-
-        data = json.loads(out_file.read_text())
-        assert data["intent"] == "Test pack from work"
-        assert data["to"] == home_did
-
-    def test_pack_resolves_label(self, profile_with_trusted: Path, tmp_path: Path) -> None:
-        out_file = tmp_path / "packet.json"
-        result = runner.invoke(
-            app,
-            [
-                "pack",
-                "--to",
-                "home",  # label, not raw DID
-                "--intent",
-                "Resolved by label",
-                "--out",
-                str(out_file),
-                "--profile",
-                str(profile_with_trusted),
-                "--format",
-                "text",
-            ],
-            input="data\n",
-        )
-        assert result.exit_code == 0, result.output
-        assert out_file.exists()
-
-    def test_pack_unknown_recipient_fails(self, profile_with_instance: Path) -> None:
-        result = runner.invoke(
-            app,
-            [
-                "pack",
-                "--to",
-                "nobody",
-                "--intent",
-                "fail",
-                "--profile",
-                str(profile_with_instance),
-            ],
-            input="data\n",
-        )
-        assert result.exit_code != 0
-
-    def test_pack_missing_profile_fails(self, tmp_path: Path) -> None:
-        result = runner.invoke(
-            app,
-            [
-                "pack",
-                "--to",
-                "did:key:z6Mkfake",
-                "--intent",
-                "fail",
-                "--profile",
-                str(tmp_path / "missing.json"),
-            ],
-            input="data\n",
-        )
-        assert result.exit_code != 0
-
-    def test_pack_missing_instance_fails(self, profile_path: Path, tmp_path: Path) -> None:
-        # Profile exists but has no instances
-        profile_path.write_text(json.dumps({}))
-        result = runner.invoke(
-            app,
-            [
-                "pack",
-                "--to",
-                "did:key:z6Mkfake",
-                "--intent",
-                "fail",
-                "--as",
-                "default",
-                "--profile",
-                str(profile_path),
-            ],
-            input="data\n",
-        )
-        assert result.exit_code != 0
-
-    def test_pack_smart_default_single_named_instance(
-        self, profile_with_named_instance: Path, tmp_path: Path
-    ) -> None:
-        """When only one instance exists and its name differs from --as, use it anyway."""
-        p = Profile.load(profile_with_named_instance)
-        # Add a trusted key so the pack can resolve a recipient
-        remote = Identity.generate("remote")
-        p.trusted_keys["remote"] = TrustedKey(
-            did=remote.did, label="remote", nostr_pubkey=remote.nostr_public_hex
-        )
-        p.save(profile_with_named_instance)
-
-        out_file = tmp_path / "packet.json"
-        result = runner.invoke(
-            app,
-            [
-                "pack",
-                "--to",
-                "remote",
-                "--intent",
-                "smart default test",
-                "--out",
-                str(out_file),
-                "--as",
-                "default",  # no 'default' instance — only 'work' exists
-                "--profile",
-                str(profile_with_named_instance),
-                "--format",
-                "text",
-            ],
-            input="hello\n",
-        )
-        assert result.exit_code == 0, result.output
-        assert out_file.exists()
-
-    def test_pack_multiple_instances_shows_available_names(
-        self, profile_with_multiple_instances: Path, tmp_path: Path
-    ) -> None:
-        """When multiple instances exist and requested one is absent, error lists them."""
-        result = runner.invoke(
-            app,
-            [
-                "pack",
-                "--to",
-                "did:key:z6Mkfake",
-                "--intent",
-                "fail",
-                "--as",
-                "default",
-                "--profile",
-                str(profile_with_multiple_instances),
-            ],
-            input="data\n",
-        )
-        assert result.exit_code != 0
-        # Error should mention all available instance names
-        combined = result.stdout + (result.stderr or "")
-        assert "work" in combined
-        assert "laptop" in combined
-
-    def test_pack_no_instances_prompts_init(
-        self, profile_with_no_instances: Path, tmp_path: Path
-    ) -> None:
-        """When no instances exist, error tells user to run aya init."""
-        result = runner.invoke(
-            app,
-            [
-                "pack",
-                "--to",
-                "did:key:z6Mkfake",
-                "--intent",
-                "fail",
-                "--as",
-                "default",
-                "--profile",
-                str(profile_with_no_instances),
-            ],
-            input="data\n",
-        )
-        assert result.exit_code != 0
-        combined = result.stdout + (result.stderr or "")
-        assert "aya init" in combined
-
-
 # ── schedule remind ──────────────────────────────────────────────────────────
 
 
@@ -2544,25 +2356,14 @@ class TestPacketPersistence:
         assert len(packet_files) == 1
         assert packet_files[0].stem == pkt.id
 
-    def test_show_displays_packet(self, packets_dir: Path, sample_packet: Packet) -> None:
-        """show command displays packet content."""
+    def test_read_panel_displays_body(self, packets_dir: Path, sample_packet: Packet) -> None:
+        """read --panel renders body in a Rich panel with title."""
         packet_file = packets_dir / f"{sample_packet.id}.json"
         packet_file.write_text(sample_packet.to_json())
 
-        result = runner.invoke(app, ["show", sample_packet.id[:8], "--format", "text"])
+        result = runner.invoke(app, ["read", sample_packet.id[:8], "--panel", "--format", "text"])
         assert result.exit_code == 0, result.output
         assert "daily handoff" in result.output
-
-    def test_show_json_format(self, packets_dir: Path, sample_packet: Packet) -> None:
-        """show --format json returns valid JSON with expected fields."""
-        packet_file = packets_dir / f"{sample_packet.id}.json"
-        packet_file.write_text(sample_packet.to_json())
-
-        result = runner.invoke(app, ["show", sample_packet.id[:8], "--format", "json"])
-        assert result.exit_code == 0, result.output
-        data = json.loads(result.output)
-        assert data["intent"] == "daily handoff"
-        assert data["id"] == sample_packet.id
 
     def test_packets_list(
         self,
@@ -2584,10 +2385,10 @@ class TestPacketPersistence:
         data = json.loads(result.output)
         assert len(data["packets"]) == 3
 
-    def test_show_unknown_id(self, packets_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        """show with an unknown ID exits nonzero."""
+    def test_read_unknown_id(self, packets_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """read with an unknown ID exits nonzero."""
         monkeypatch.setenv("AYA_FORMAT", "json")
-        result = runner.invoke(app, ["show", "00000000unknown"])
+        result = runner.invoke(app, ["read", "00000000unknown"])
         assert result.exit_code != 0
 
 
@@ -3972,34 +3773,18 @@ class TestMaybeCreateCiWatchRepoParsing:
             mock_watches.assert_not_called()
 
 
-# ── send/send-raw/pack help text cross-references ───────────────────────────
+# ── send/send-raw help text cross-references ─────────────────────────────────
 
 
 class TestCommandHelpCrossReferences:
-    """Verify that send, send-raw, and pack help text cross-references each other."""
+    """Verify that send and send-raw help text cross-reference each other."""
 
     def test_send_raw_help_mentions_send(self):
         result = runner.invoke(app, ["send-raw", "--help"])
         assert result.exit_code == 0, result.output
         assert "aya send" in result.output
 
-    def test_send_raw_help_mentions_pack(self):
-        result = runner.invoke(app, ["send-raw", "--help"])
-        assert result.exit_code == 0, result.output
-        assert "aya pack" in result.output
-
-    def test_pack_help_mentions_send(self):
-        result = runner.invoke(app, ["pack", "--help"])
-        assert result.exit_code == 0, result.output
-        assert "aya send" in result.output
-
-    def test_pack_help_mentions_send_raw(self):
-        result = runner.invoke(app, ["pack", "--help"])
-        assert result.exit_code == 0, result.output
-        assert "aya send-raw" in result.output
-
-    def test_send_help_mentions_pack_and_send_raw(self):
+    def test_send_help_mentions_send_raw(self):
         result = runner.invoke(app, ["send", "--help"])
         assert result.exit_code == 0, result.output
-        assert "aya pack" in result.output
-        assert "aya send-raw" in result.output
+        assert "send-raw" in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2365,6 +2365,26 @@ class TestPacketPersistence:
         assert result.exit_code == 0, result.output
         assert "daily handoff" in result.output
 
+    def test_read_panel_preserves_bracket_sequences(self, packets_dir: Path) -> None:
+        """read --panel must not interpret [...] in the body as Rich markup."""
+        local = Identity.generate("default")
+        home = Identity.generate("home")
+        # Body contains text that Rich would normally treat as markup.
+        body_with_markup = "log line: [error] something [bold]important[/bold] happened"
+        pkt = Packet(
+            **{"from": home.did, "to": local.did},
+            intent="log",
+            content=body_with_markup,
+        )
+        (packets_dir / f"{pkt.id}.json").write_text(pkt.to_json())
+
+        result = runner.invoke(app, ["read", pkt.id[:8], "--panel", "--format", "text"])
+        assert result.exit_code == 0, result.output
+        # The literal [error] / [bold] text must survive — it should NOT be
+        # consumed or applied as markup.
+        assert "[error]" in result.output
+        assert "[bold]" in result.output
+
     def test_packets_list(
         self,
         packets_dir: Path,

--- a/tests/test_json_contract.py
+++ b/tests/test_json_contract.py
@@ -346,16 +346,3 @@ class TestScheduleAlertsContract:
         alert = alerts_list[0]
         for key in ("id", "source_item_id", "message", "seen"):
             assert key in alert, f"missing alert key: {key}"
-
-
-# ── schedule check ───────────────────────────────────────────────────────────
-
-
-class TestScheduleCheckContract:
-    def test_top_level_keys(self):
-        """schedule check --format json has due and alerts."""
-        data = _invoke_json("schedule", "check")
-        assert "due" in data
-        assert "alerts" in data
-        assert isinstance(data["due"], list)
-        assert isinstance(data["alerts"], list)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -25,7 +25,6 @@ def test_list_tools_names():
         "aya_schedule_remind",
         "aya_schedule_watch",
         "aya_ack",
-        "aya_show",
         "aya_read",
         "aya_config_set",
         "aya_config_show",


### PR DESCRIPTION
## Summary

Second slice of the CLI surface review. Tier 2 is the local-only consolidation tier — nothing here touches the cross-instance or hook-wired contracts, so home + work stay in sync without coordinated upgrades.

**Removed:**
- `aya pack` — `aya send` is the canonical pack-and-publish flow; `pack` had no callers in skills, hooks, or MCP, and its help text already redirected users to `send`. If you genuinely need to build a packet without publishing, build the JSON manually and use `send-raw`.
- `aya show` → collapsed into `aya read`. Pass `--panel` to `read` for the boxed display the old `show` produced. The MCP `aya_show` tool is removed in lockstep:
  - `aya_read(meta=true)` returns the structured fields most callers want.
  - For the full signed envelope, read `~/.aya/packets/<id>.json` directly.
- `aya schedule check` — partial reimplementation of `pending` + `alerts`. Use:
  - `aya schedule pending` for due reminders + actionable alerts (the SessionStart payload).
  - `aya schedule alerts [--mark-seen]` for the alert queue alone.

Net: **−409 lines**, 9 files touched.

## What stays the same

- All cross-instance flows (`send`, `receive`, `ack`, `pair`).
- All hook-wired commands (`schedule activity`, `schedule tick`, `hook crons`, `hook watch`).
- The `Packet`/`MCP` data shapes for what does ship — only the redundant entry points went away.
- `aya read --format json --meta` produces the same shape; new `--panel` flag is text-only.

## Test plan

- [x] `uv run pytest` — 688 passed
- [x] `uv run ruff check src tests` — clean
- [x] `uv run ruff format --check src tests` — clean
- [x] `uv run mypy src` — clean
- [x] `aya --help` shows the trimmed surface; `aya pack`, `aya show`, `aya schedule check` correctly report "No such command"
- [x] `aya read <id> --panel` renders the boxed display formerly emitted by `show`
- [ ] After merge: refresh aya on home + work

## Follow-ups

Tier 3 (design discussion, not in scope for this PR): the `ack` sugar over `send`, the `inbox`/`packets` naming clarification, and any rename of hook-wired commands. Those need a stable-contract migration plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)