### PR TITLE
feat(gateway): bundle nanoleaf-kitt in image, NANOLEAF_TOKEN via env_file (closes #265)

### DIFF
--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -28,10 +28,20 @@ ENV GIT_SHA=${GIT_SHA} \
     PATH=/opt/venv/bin:$PATH
 
 # Non-root runtime user. Numeric UID 1001 to avoid host UID collisions.
+# /home/gateway is intentionally minimal (no shell, no full home tree) — only
+# the cache dir nanoleaf-kitt expects for its layout cache is pre-created.
 RUN groupadd --system --gid 1001 gateway \
-    && useradd --system --uid 1001 --gid gateway --no-create-home gateway
+    && useradd --system --uid 1001 --gid gateway --no-create-home gateway \
+    && mkdir -p /home/gateway/.config/nanoleaf-direct \
+    && chown -R gateway:gateway /home/gateway
 
 COPY --from=builder /opt/venv /opt/venv
+
+# Effect runners (stdlib-only Python; no extra image deps).
+# Layout cache is fetched on first use into /home/gateway/.config/nanoleaf-direct/
+# and persists across container restarts in the writable layer.
+COPY effects/nanoleaf-kitt /usr/local/bin/nanoleaf-kitt
+RUN chmod 0755 /usr/local/bin/nanoleaf-kitt
 
 WORKDIR /app
 COPY --chown=gateway:gateway app /app/app

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -34,31 +34,72 @@ tmpfs on Linux and gets wiped on every reboot.
 ### Bootstrap (one-time, on the host)
 
 ```bash
-# Pull the credential from 1Password and write it next to docker-compose.yml.
+# Pull credentials from 1Password and write them next to docker-compose.yml.
 # Run this once from inside the compose directory on Babar.
 cd /volume1/docker/projects/aya-gateway-compose
-op read 'op://Private/aya-gateway/credential' \
-  | sed 's/^/GATEWAY_BEARER=/' \
-  > .env
+{
+  printf 'GATEWAY_BEARER=%s\n' "$(op read 'op://Private/aya-gateway/credential')"
+  printf 'NANOLEAF_TOKEN=%s\n' "$(op read 'op://Private/Nanoleaf - Token - Light Panels/credential')"
+} > .env
 sudo chmod 600 .env
 sudo chown root:root .env
 ```
 
-The file must contain a single line:
+The file should contain two lines:
 
 ```
-GATEWAY_BEARER=<your-token>
+GATEWAY_BEARER=<your-bearer-token>
+NANOLEAF_TOKEN=<your-nanoleaf-token>
 ```
+
+`GATEWAY_BEARER` gates every authenticated route. `NANOLEAF_TOKEN` is
+read by the `nanoleaf-kitt` script bundled in the image (see
+[Effects](#effects)) when `/effects/kitt` invokes it; if the route
+isn't deployed yet, the var is harmless to have set.
 
 ### Rotation
 
-1. Update the credential in 1Password (`op://Private/aya-gateway/credential`).
+1. Update the relevant credential in 1Password.
 2. Regenerate the `.env` file on the host (same command as Bootstrap above).
-3. Restart the container to pick up the new token — DSM Container
+3. Restart the container to pick up the new value — DSM Container
    Manager → Container → `aya-gateway` → Restart, or via SSH:
    ```bash
    ssh babar 'docker restart aya-gateway'
    ```
+
+## Effects
+
+The image bundles stdlib-only Python helpers under `/usr/local/bin/`
+that the gateway's effect routes (`/effects/*`) shell out to. Bundling
+keeps the container fully self-describing — no host-side script
+mounting, no cross-machine RPC.
+
+| Script | Source | Purpose |
+|---|---|---|
+| `nanoleaf-kitt` | `effects/nanoleaf-kitt` | KITT-style scanner across the office Nanoleaf panels |
+
+`nanoleaf-kitt` reads `NANOLEAF_TOKEN` from the environment (`env_file:
+./.env`) and talks to the controller at `192.168.50.31:16021` over
+LAN. It's a vendored copy of `~/.preflight/bin/nanoleaf-kitt` from the
+dev box; updates to the upstream script need to be re-vendored here.
+
+### Layout cache
+
+The Nanoleaf controller exposes a `/panelLayout/layout` endpoint. The
+script caches the response at `/home/gateway/.config/nanoleaf-direct/layout.json`
+**on first invocation** rather than baking it into the image — the
+image stays generic across panel configurations, and a re-pair or
+hardware swap just refreshes the cache on next call. The cache lives
+in the container's writable layer, persisting across restarts and
+clearing on rebuild.
+
+Manual smoke test (after the container has `NANOLEAF_TOKEN` set):
+
+```bash
+ssh babar 'docker exec aya-gateway nanoleaf-kitt --color blue --period 2'
+# Panels should display a blue scanner; Ctrl-C ends the command but
+# the animation continues until something else changes panel state.
+```
 
 ## Quickstart (local dev)
 
@@ -150,7 +191,7 @@ convention puts compose project dirs under `/volume1/docker/projects/`
 ssh babar 'sudo mkdir -p /volume1/docker/projects/aya-gateway-compose && sudo chown $USER:users /volume1/docker/projects/aya-gateway-compose'
 rsync -av --delete \
   --exclude='__pycache__' --exclude='.venv' --exclude='*.pyc' --exclude='tests' \
-  Dockerfile docker-compose.yml pyproject.toml uv.lock app \
+  Dockerfile docker-compose.yml pyproject.toml uv.lock app effects \
   babar:/volume1/docker/projects/aya-gateway-compose/
 ```
 
@@ -158,7 +199,7 @@ rsync -av --delete \
 Option B: DSM File Station
   1. In /volume1/docker/projects/, create folder aya-gateway-compose
   2. Drag-and-drop Dockerfile, docker-compose.yml, pyproject.toml,
-     uv.lock, and the app/ directory into it
+     uv.lock, and the app/ + effects/ directories into it
 ```
 
 **3. Write the .env file on Babar**
@@ -300,7 +341,7 @@ rebuild via the UI:
 # 1. Re-stage source on Babar
 rsync -av --delete \
   --exclude='__pycache__' --exclude='.venv' --exclude='*.pyc' --exclude='tests' \
-  Dockerfile docker-compose.yml pyproject.toml uv.lock app \
+  Dockerfile docker-compose.yml pyproject.toml uv.lock app effects \
   babar:/volume1/docker/projects/aya-gateway-compose/
 ```
 
@@ -335,6 +376,8 @@ gateway/
 ├── app/
 │   ├── __init__.py
 │   └── main.py          # FastAPI app, /health, bearer-auth dependency
+├── effects/
+│   └── nanoleaf-kitt    # vendored from ~/.preflight/bin (stdlib-only)
 ├── tests/
 │   ├── conftest.py      # sets GATEWAY_BEARER for the test run
 │   ├── test_auth.py     # bearer-token auth tests

--- a/gateway/effects/nanoleaf-kitt
+++ b/gateway/effects/nanoleaf-kitt
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""nanoleaf-kitt — KITT-style scanner across the office Nanoleaf panels.
+
+A bright dot bounces left-to-right along the panel array, with a fading
+comet trail behind it in the direction of travel. End-hold on each
+bounce gives a natural pause before reversing. Loops continuously
+until panel state is changed (e.g., via HA's light.turn_on).
+
+Reads token from $NANOLEAF_TOKEN, then ~/.config/nanoleaf-direct/env,
+then ~/.config/nanoleaf-direct/token.json. Layout cached at
+~/.config/nanoleaf-direct/layout.json.
+
+Fire-and-forget: this script does not snapshot or restore. Callers
+handle the lifecycle (light-remind --tone kitt-pan does it for you).
+
+Usage:
+  nanoleaf-kitt                                  # red, 1.8s/cycle, trail 4
+  nanoleaf-kitt --color blue                     # blue scanner
+  nanoleaf-kitt --period 2.7                     # slower, more deliberate
+  nanoleaf-kitt --trail 5                        # longer comet
+  nanoleaf-kitt --color 0,255,200 --period 1.4   # custom
+
+Note: minimum cycle period is bounded by the panel count — for 9
+panels the floor is 1.8s (100ms × 18 frames). Asking for a shorter
+period clamps to that minimum.
+"""
+
+import argparse
+import json
+import os
+import pathlib
+import sys
+import urllib.error
+import urllib.request
+
+CTRL_HOST = "192.168.50.31"
+CTRL_PORT = 16021
+CFG_DIR = pathlib.Path.home() / ".config/nanoleaf-direct"
+LAYOUT_CACHE = CFG_DIR / "layout.json"
+TOKEN_JSON = CFG_DIR / "token.json"
+ENV_FILE = CFG_DIR / "env"
+
+NAMED_COLORS = {
+    "red":    (255,   0,   0),
+    "amber":  (255, 140,   0),
+    "green":  (  0, 200,  80),
+    "blue":   ( 40, 120, 255),
+    "white":  (255, 255, 255),
+    "purple": (160,  80, 255),
+    "cyan":   (  0, 200, 200),
+}
+
+
+def load_token():
+    t = os.environ.get("NANOLEAF_TOKEN")
+    if t:
+        return t
+    if ENV_FILE.exists():
+        for line in ENV_FILE.read_text().splitlines():
+            if line.startswith("NANOLEAF_TOKEN="):
+                return line.split("=", 1)[1].strip()
+    if TOKEN_JSON.exists():
+        return json.loads(TOKEN_JSON.read_text())["auth_token"]
+    sys.exit("nanoleaf-kitt: no token (set $NANOLEAF_TOKEN or "
+             f"populate {TOKEN_JSON})")
+
+
+def http(method, path, body=None, timeout=5):
+    url = f"http://{CTRL_HOST}:{CTRL_PORT}{path}"
+    data = json.dumps(body).encode() if body is not None else None
+    headers = {"Content-Type": "application/json"} if body is not None else {}
+    req = urllib.request.Request(url, method=method, data=data, headers=headers)
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return resp.read().decode()
+
+
+def get_layout(token):
+    if LAYOUT_CACHE.exists():
+        return json.loads(LAYOUT_CACHE.read_text())
+    raw = http("GET", f"/api/v1/{token}/panelLayout/layout")
+    CFG_DIR.mkdir(parents=True, exist_ok=True)
+    LAYOUT_CACHE.write_text(raw)
+    return json.loads(raw)
+
+
+def parse_color(s):
+    if s in NAMED_COLORS:
+        return NAMED_COLORS[s]
+    parts = s.split(",")
+    if len(parts) != 3:
+        sys.exit(f"nanoleaf-kitt: --color must be a name "
+                 f"({'/'.join(NAMED_COLORS)}) or 'r,g,b'")
+    try:
+        rgb = tuple(int(p.strip()) for p in parts)
+    except ValueError:
+        sys.exit(f"nanoleaf-kitt: invalid RGB: {s!r}")
+    if not all(0 <= c <= 255 for c in rgb):
+        sys.exit("nanoleaf-kitt: RGB values must be 0-255")
+    return rgb
+
+
+def trail_intensities(rgb, trail_len):
+    """Geometric 0.5× decay from peak rgb."""
+    return [tuple(int(round(c * (0.5 ** i))) for c in rgb)
+            for i in range(trail_len)]
+
+
+def build_animdata(panel_ids, rgb, trail_len, dc_per_frame):
+    """Bounce 0→n-1→0 (2n frames). Each endpoint appears twice in
+    consecutive frames with direction flipping between — gives a
+    natural pause at each bounce.
+    """
+    n = len(panel_ids)
+    trail = trail_intensities(rgb, trail_len)
+    positions = list(range(n)) + list(range(n - 1, -1, -1))
+    moving_right = [True] * n + [False] * n
+    n_frames = len(positions)
+
+    parts = [str(n)]
+    for j, pid in enumerate(panel_ids):
+        parts += [str(pid), str(n_frames)]
+        for f in range(n_frames):
+            head = positions[f]
+            dist = (head - j) if moving_right[f] else (j - head)
+            r, g, b = trail[dist] if 0 <= dist < trail_len else (0, 0, 0)
+            parts += [str(r), str(g), str(b), "0", str(dc_per_frame)]
+    return " ".join(parts)
+
+
+def fire_kitt(token, rgb, period_s, trail_len):
+    layout = get_layout(token)
+    panels = sorted(layout["positionData"], key=lambda p: p["x"])
+    panel_ids = [p["panelId"] for p in panels]
+    n_frames = 2 * len(panel_ids)
+    dc_per_frame = max(1, int(round(period_s * 10 / n_frames)))
+    animdata = build_animdata(panel_ids, rgb, trail_len, dc_per_frame)
+    body = {
+        "write": {
+            "command": "display",
+            "version": "2.0",
+            "animType": "custom",
+            "animData": animdata,
+            "loop": True,
+            "palette": [],
+        }
+    }
+    try:
+        http("PUT", f"/api/v1/{token}/effects", body)
+    except urllib.error.HTTPError as e:
+        sys.exit(f"nanoleaf-kitt: HTTP {e.code} from controller — "
+                 f"token may be invalid")
+
+
+def main():
+    p = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("--color", default="red",
+                   help=f"color name ({'/'.join(NAMED_COLORS)}) or 'r,g,b'")
+    p.add_argument("--period", type=float, default=1.8,
+                   help="cycle time in seconds (default 1.8)")
+    p.add_argument("--trail", type=int, default=4,
+                   help="trail length in panels (default 4)")
+    args = p.parse_args()
+
+    if args.trail < 1:
+        sys.exit("nanoleaf-kitt: --trail must be >= 1")
+
+    token = load_token()
+    rgb = parse_color(args.color)
+    fire_kitt(token, rgb, args.period, args.trail)
+
+
+if __name__ == "__main__":
+    main()

--- a/gateway/effects/nanoleaf-kitt
+++ b/gateway/effects/nanoleaf-kitt
@@ -53,6 +53,8 @@ NAMED_COLORS = {
 
 def load_token():
     t = os.environ.get("NANOLEAF_TOKEN")
+    if t is not None:
+        t = t.strip()
     if t:
         return t
     if ENV_FILE.exists():


### PR DESCRIPTION
Closes #265.

## Summary

Bundles the KITT scanner script into the gateway container so `/effects/kitt` (a later PR, #266) can shell out to it without depending on the dev box being up. Promotes the Nanoleaf token to 1Password and rides it into the container alongside `GATEWAY_BEARER`.

## Decisions

| Acceptance criterion | Decision | Rationale |
|---|---|---|
| Where the script lives in the repo | `gateway/effects/nanoleaf-kitt`, vendored from `~/.preflight/bin/nanoleaf-kitt` | Domain-named (matches `/effects/kitt`); leaves room for siblings (`nanoleaf-streak`, etc.). Source-of-truth question deferred — noted in cross-refs |
| Layout cache strategy | **Fetch on first use** (script's existing `get_layout()` behavior) — *not* baked into the image | Image stays generic across panel configurations; re-pair / hardware swap just refreshes the cache on next call. Cache persists in writable layer across restarts, refreshes on rebuild |
| Token storage | `op://Private/Nanoleaf - Token - Light Panels/credential` (matches issue spec) | Closes existing 1Password TODO in `notebook/projects/nanoleaf-direct/README.md` |
| Token delivery to container | Append `NANOLEAF_TOKEN` to the same `.env` as `GATEWAY_BEARER` | Single secrets file, single rotation point. Bootstrap snippet in README now reads both creds in one block |
| Container home dir | Pre-create `/home/gateway/.config/nanoleaf-direct/` in Dockerfile, owned by `gateway:gateway` | `useradd --no-create-home` is preserved for hardening; we explicitly carve out only the cache dir the script needs |
| `COPY --chmod` | Reverted to `COPY` + `RUN chmod` | `--chmod` requires BuildKit; classic builder (potentially DSM Container Manager's) doesn't honor it |

## What changed

- `gateway/Dockerfile` — pre-create `/home/gateway/.config/nanoleaf-direct/`, copy + chmod `nanoleaf-kitt` to `/usr/local/bin/`
- `gateway/README.md` — new **Effects** section, dual-cred Bootstrap snippet in Auth, expanded Layout footer, updated rsync exclusions
- `gateway/effects/nanoleaf-kitt` — vendored script (NEW, 6014 bytes, mode 755)

Notebook update (separate repo): `notebook/projects/nanoleaf-direct/README.md` marks the 1Password TODO done with the credential location.

## Verification

Local image build + run, all green:

```
$ docker run --rm aya-gateway:dev nanoleaf-kitt --help
usage: nanoleaf-kitt [-h] [--color COLOR] [--period PERIOD] [--trail TRAIL]
…
(exit 0)

$ docker run --rm aya-gateway:dev sh -c 'id && ls -ld /home/gateway/.config/nanoleaf-direct'
uid=1001(gateway) gid=1001(gateway) groups=1001(gateway)
drwxr-xr-x 3 gateway gateway 4096 May  1 20:29 /home/gateway/.config/nanoleaf-direct
```

CI: ruff / format / mypy / pytest all green locally before push.

## Test plan (post-merge, on Babar)

The remaining acceptance criteria require manual on-Babar steps:

- [ ] **1Password item** — `op item create --category="API Credential" --vault=Private --title="Nanoleaf - Token - Light Panels" credential="$(cat ~/.config/nanoleaf-direct/token.json | python3 -c 'import json,sys; print(json.load(sys.stdin)["auth_token"])')"` (one-time, dev box, interactive `op-signin` first)
- [ ] **Re-stage source on Babar** — rsync now includes `effects/`
- [ ] **Append `NANOLEAF_TOKEN` to `.env`** — bootstrap snippet in the updated Auth section reads both creds
- [ ] **DSM Container Manager → Project → aya-gateway → Build → Run** — picks up the new Dockerfile + script
- [ ] **End-to-end smoke** — `ssh babar 'docker exec aya-gateway nanoleaf-kitt --color blue --period 2'` and observe panels respond
- [ ] **Clean up** — once verified working, the local `~/.config/nanoleaf-direct/token.json` JSON backup is optional; 1Password is now source of truth

## Out of scope (queued)

- #266 — `POST /effects/kitt` HTTP route
- #267 — Home Assistant `rest_command.kitt_start` wired to Office Mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)