### PR TITLE
feat(opencode): add GitHub Actions workflow for opencode integration

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -1,0 +1,33 @@
+name: opencode
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  opencode:
+    if: |
+      contains(github.event.comment.body, ' /oc') ||
+      startsWith(github.event.comment.body, '/oc') ||
+      contains(github.event.comment.body, ' /opencode') ||
+      startsWith(github.event.comment.body, '/opencode')
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: read
+      issues: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run opencode
+        uses: anomalyco/opencode/github@latest
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        with:
+          model: anthropic/claude-sonnet-4-6


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow named `opencode` that enables triggering the OpenCode bot via specific comment commands on issues and pull request review comments. The workflow checks out the code and runs the `anomalyco/opencode` GitHub Action using the Anthropic Claude Sonnet model.

**New workflow for OpenCode bot:**

* Adds a `.github/workflows/opencode.yml` workflow that listens for issue and PR review comments containing `/oc` or `/opencode` commands, checks out the repository, and runs the OpenCode GitHub Action with Anthropic Claude Sonnet 4-6, using the `ANTHROPIC_API_KEY` secret for authentication.