### PR TITLE
docs(skills): pin aya refresh to Python 3.13 (coincurve/cffi wheel gap on 3.14)

### DIFF
--- a/skills/aya/SKILL.md
+++ b/skills/aya/SKILL.md
@@ -262,6 +262,16 @@ Refresh is **CLI-only** — `uv tool` installer commands and
 `aya schedule install` have no MCP equivalents. Reinstall aya, with
 verification.
 
+> **Pin a wheel-compatible Python.** aya depends on `coincurve`/`cffi`, which
+> lag the newest CPython. On Python 3.14 there are no wheels yet, so uv builds
+> them from source and `cffi` fails (`Expected exactly one LICENSE file in cffi
+> distribution`). Install with `--python 3.13` (the newest interpreter that has
+> coincurve + cffi wheels) on both paths below; bump it when 3.14 wheels land.
+> `uv tool upgrade` preserves the env's interpreter, so only fresh installs and
+> `--force` reinstalls need the flag. (This replaces the older `coincurve<21`
+> constraint workaround, which pinned an outdated coincurve instead of fixing
+> the wheel gap.)
+
 ### Detect install source first
 
 Before reinstalling, check whether the current install is editable from
@@ -296,7 +306,7 @@ denote the path read from the receipt (e.g. `~/dev/code/aya`):
 2. **Reinstall editable** (re-syncs deps from `pyproject.toml`):
 
    ```bash
-   uv tool install --editable <aya-clone> --reinstall
+   uv tool install --editable <aya-clone> --reinstall --python 3.13
    ```
 
 3. Continue at **Common steps** below.
@@ -314,7 +324,7 @@ When the receipt is missing or non-editable:
 2. **Reinstall latest from GitHub:**
 
    ```bash
-   uv tool install --from git+https://github.com/shawnoster/aya aya-ai-assist --force
+   uv tool install --from git+https://github.com/shawnoster/aya aya-ai-assist --python 3.13 --force
    ```
 
 3. Continue at **Common steps** below.


### PR DESCRIPTION
## Summary

- The `/aya` Refresh skill reinstalls via `uv tool install ... --force` with no Python pin. On a box where the default interpreter is **Python 3.14**, `coincurve`/`cffi` have no wheels yet, so uv builds them from source and `cffi` fails (`Expected exactly one LICENSE file in cffi distribution`) — a clean `--force` reinstall breaks.
- Pin both Refresh install paths to `--python 3.13` (the newest interpreter with coincurve + cffi wheels) and add a note explaining why. This replaces the older `coincurve<21` constraint workaround, which pinned an outdated coincurve instead of fixing the wheel gap.

## Type of change

- [x] Docs / config only

## Related issues

none

## Test plan

Reproduced on a Python 3.14.3 box: `uv tool install --from git+… aya-ai-assist --force` failed building cffi for coincurve 21. Reinstalling with `--python 3.13` resolved `coincurve==21.0.0` + `cffi==2.0.0` from prebuilt wheels (no build), `aya version` → 1.45.0, `aya status` systems ok, and the receipt no longer needs the `coincurve<21` constraint. `uv tool upgrade` was confirmed to preserve the env interpreter, so only fresh installs/`--force` need the flag.

## Checklist

- [x] Commit messages follow Conventional Commits
- [ ] Tests added or updated for changed behavior — n/a, skill doc only
- [ ] `make check` passes locally — n/a, no code changed
- [ ] Pre-commit hooks installed and passing — n/a, doc-only edit
- [x] Docs updated if behavior changed
- [x] No secrets, credentials, or personal data committed
